### PR TITLE
Tune up the realpath cache

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -50,6 +50,8 @@ RUN BUILDDEPS='php7.2-dev build-essential git liblttng-ust-dev' ;\
     apt-get remove -y --purge $BUILDDEPS; \
     apt-get autoremove -y --purge; apt-get clean
 
+COPY php.ini /etc/php/7.2/cli/conf.d/95-epfl.ini
+
 RUN a2enmod cgi
 
 # directory for custom error pages

--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -1,0 +1,5 @@
+;; EPFL-specific tunings for PHP
+
+realpath_cache_size = 40M
+realpath_cache_ttl = 1800
+


### PR DESCRIPTION
As per yesterday's strace(1)-based examination, this is a candidate
for boosting performance by reducing the number of round trips to the
NAS.