### PR TITLE
Change deprecated access control directives

### DIFF
--- a/docker/httpd/apache2.conf
+++ b/docker/httpd/apache2.conf
@@ -23,8 +23,7 @@ AccessFileName .htaccess
         Require all denied
 </FilesMatch>
 <FilesMatch "xmlrpc.php">
-        Order deny,allow
-        Deny from all
+        Require all denied
 </FilesMatch>
 <Directory "/">
         AllowOverride All
@@ -33,9 +32,7 @@ AccessFileName .htaccess
 ExtendedStatus on
 <Location /mod_status>
         SetHandler server-status
-        Order deny,allow
-        Deny from all
-        Allow from 127.0.0.1 localhost
+        Require local
 </Location>
 
 ScriptAlias /ready /usr/lib/cgi-bin/health.cgi


### PR DESCRIPTION
The `allow`, `deny`, `order` access control directives are deprecated. Replace them with the new one.