### PR TITLE
Fix GPG error

### DIFF
--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -22,13 +22,14 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     screen \
     software-properties-common \
     unzip \
-    vim \
+    vim \   
+    ca-certificates \
   && \
     apt-get -y autoremove && \
     apt-get clean
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN curl https://packages.sury.org/php/apt.gpg > /etc/apt/trusted.gpg.d/php.gpg
+RUN curl -sL https://packages.sury.org/php/apt.gpg > /etc/apt/trusted.gpg.d/php.gpg
 RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 RUN apt-get -y update
 # The following goodies have dependencies above this line, and

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -22,8 +22,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     screen \
     software-properties-common \
     unzip \
-    vim \   
-    ca-certificates \
+    vim \
   && \
     apt-get -y autoremove && \
     apt-get clean


### PR DESCRIPTION
Fix de l'erreur qui est apparue lors du build de l'image.

> WARNING: The following packages cannot be authenticated!
  php7.1-common php7.1-json php7.1-opcache php7.1-readline php7.1-cli
  libapache2-mod-php7.1 libgd3 libzip5 php7.1 php7.1-curl php7.1-gd
  php7.1-ldap php7.1-mysql php7.1-xml php7.1-zip
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
Removing intermediate container 9335932b4735
error: build error: The command '/bin/sh -c apt-get -y install nodejs     php7.1     php7.1-gd     php7.1-cli     php7.1-curl     php7.1-ldap     php7.1-mysql     php7.1-xml     php7.1-zip   &&     apt-get -y autoremove &&     apt-get clean' returned a non-zero code: 100
