### PR TITLE
Add support for web services metrics

### DIFF
--- a/docker/httpd/docker-entrypoint.sh
+++ b/docker/httpd/docker-entrypoint.sh
@@ -24,6 +24,11 @@ VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"
   SSLCertificateFile "/etc/apache2/ssl/server.cert"
   SSLCertificateKeyFile "/etc/apache2/ssl/server.key"
 </VirtualHost>
+
+<VirtualHost *:9980>
+  VirtualDocumentRoot "/srv/${WP_ENV}/${WP_ENV}-metrics/htdocs"
+  ProxyPreserveHost On
+</VirtualHost>
 EOF
 
 /bin/mkdir -p /srv/${WP_ENV}/logs
@@ -50,6 +55,9 @@ sed -i "s/post_max_size = .*/post_max_size = 300M/" /etc/php/7.2/cli/php.ini
 /usr/sbin/a2enmod ssl
 /usr/sbin/a2enmod rewrite
 /usr/sbin/a2enmod vhost_alias
+/usr/sbin/a2enmod proxy
+/usr/sbin/a2enmod proxy_http
+/usr/sbin/a2enmod headers
 /usr/sbin/a2enmod status
 /usr/sbin/a2enmod remoteip
 /usr/sbin/a2enconf dyn-vhost

--- a/docker/httpd/ports.conf
+++ b/docker/httpd/ports.conf
@@ -1,2 +1,3 @@
 Listen 8080
 Listen 8443
+Listen 9980


### PR DESCRIPTION
Allow apache to handle requests for web services metrics.

A new document root with a `.htaccess` file must also be created in the file tree. For the `httpd-lchaboudez` pod :
```
mkdir -p /srv/lchaboudez/lchaboudez-metrics/htdocs
```
The `.htaccess`file :
```
RewriteEngine On
RewriteRule ^(.*)$ http://localhost:8080/$1 [P]
RequestHeader set Host env-lc-os-exopge.epfl.ch
```