### PR TITLE
Add X-EPFL-Trace-ID header into the apache logs

### DIFF
--- a/docker/httpd/docker-entrypoint.sh
+++ b/docker/httpd/docker-entrypoint.sh
@@ -8,7 +8,7 @@ UseCanonicalName Off
 RemoteIPHeader X-Forwarded-For
 RemoteIPInternalProxy 172.31.0.0/16 10.180.21.0/24 127.0.0.0/8
 
-LogFormat "%V %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" %T %D" vcommon
+LogFormat "%V %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" \"%{X-EPFL-Trace-Id}i\" %T %D" vcommon
 CustomLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/access_log.$(hostname).%Y%m%d 86400" vcommon
 CustomLog "/dev/stdout" vcommon
 
@@ -49,7 +49,7 @@ sed -i "s/upload_max_filesize = .*/upload_max_filesize = 300M/" /etc/php/7.2/apa
 sed -i "s/post_max_size = .*/post_max_size = 300M/" /etc/php/7.2/apache2/php.ini
 # Change max upload size for CLI requests
 sed -i "s/upload_max_filesize = .*/upload_max_filesize = 300M/" /etc/php/7.2/cli/php.ini
-sed -i "s/post_max_size = .*/post_max_size = 300M/" /etc/php/7.2/cli/php.ini
+ sed -i "s/post_max_size = .*/post_max_size = 300M/" /etc/php/7.2/cli/php.ini
 
 /usr/sbin/a2dissite 000-default
 /usr/sbin/a2enmod ssl


### PR DESCRIPTION
Change the custom log format in order to be able to log the X-EPFL-Trace-Id http header added by the A10.