### PR TITLE
Use true client IP if behind CloudFlare when 403 error

### DIFF
--- a/docker/httpd/403/403.php
+++ b/docker/httpd/403/403.php
@@ -13,7 +13,7 @@
   $request_id  = $_SERVER["UNIQUE_ID"];
   $request_uri = $_SERVER["REQUEST_URI"];
   // If using CloudFlare, we retrieve original client IP in 'HTTP_CF_CONNECTING_IP'. The content of 'REMOTE_ADDR' is a CloudFlare IP.
-  $request_ip  = (array_key_exists("HTTP_CF_CONNECTING_IP", $_SERVER))?$_SERVER["HTTP_CF_CONNECTING_IP"]:$_SERVER["REMOTE_ADDR"];
+  $request_ip  = (array_key_exists("HTTP_CF_CONNECTING_IP", $_SERVER)) ? $_SERVER["HTTP_CF_CONNECTING_IP"] : $_SERVER["REMOTE_ADDR"];
 
   // ip protocol version & regex to check if inside EPFL campus
   $ip_v = "IPv4";

--- a/docker/httpd/403/403.php
+++ b/docker/httpd/403/403.php
@@ -12,7 +12,8 @@
   // request variables
   $request_id  = $_SERVER["UNIQUE_ID"];
   $request_uri = $_SERVER["REQUEST_URI"];
-  $request_ip  = $_SERVER["REMOTE_ADDR"];
+  // If using CloudFlare, we retrieve original client IP in 'HTTP_CF_CONNECTING_IP'. The content of 'REMOTE_ADDR' is a CloudFlare IP.
+  $request_ip  = (array_key_exists("HTTP_CF_CONNECTING_IP", $_SERVER))?$_SERVER["HTTP_CF_CONNECTING_IP"]:$_SERVER["REMOTE_ADDR"];
 
   // ip protocol version & regex to check if inside EPFL campus
   $ip_v = "IPv4";


### PR DESCRIPTION
Si on a l'information de l'adresse IP originale du client (champ ajouté dans `$_SERVER` par CloudFlare), on utilise cette valeur au lieu de celle contenue dans `REMOTE_ADDR` car cette dernière contient du coup une IP CloudFlare.