### PR TITLE
Add PHP mbstring to have mb_* functions

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -31,6 +31,7 @@ RUN  apt-get -y update && \
     php7.2-xml \
     php7.2-zip \
     php7.2-apcu \
+    php7.2-mbstring \
     lttng-tools \
   && \
     apt-get -y autoremove && \


### PR DESCRIPTION
Ajout du packag PHP "mbstring" afin de pouvoir avoir les fonctions mb_* pour les encodages. Celles-ci sont typiquement utilisées au sein de https://github.com/epfl-idevelop/jahia2wp/pull/942 et https://github.com/epfl-idevelop/jahia2wp/pull/943