### PR TITLE
Remove PHP perf log file

### DIFF
--- a/docker/httpd/docker-entrypoint.sh
+++ b/docker/httpd/docker-entrypoint.sh
@@ -12,9 +12,6 @@ LogFormat "%V %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" \"%{X
 CustomLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/access_log.$(hostname).%Y%m%d 86400" vcommon
 CustomLog "/dev/stdout" vcommon
 
-LogFormat "%t \"%r\" %>s %b %{epfl_php_perf_notes}n" perf
-CustomLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/perf_log.$(hostname).%Y%m%d 86400" perf
-
 ErrorLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/error_log.$(hostname).%Y%m%d 86400"
 
 VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"


### PR DESCRIPTION
Modification qui n'avait pas été "revert" depuis décembre 2018 car on est finalement partis dans une autre direction et là, ça ne fait que remplir le filesystem avec les logs.

**POST REDEPLOIEMENT DE L'IMAGE**
- Supprimer les fichiers `/srv/www/logs/perf_log*` sur le NAS