### PR TITLE
Ability to use the install-plugins.py script manually

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -57,6 +57,6 @@ ADD wordpress-anywhere.patch /tmp/
 RUN cd /; git apply < /tmp/wordpress-anywhere.patch
 
 ADD install-plugins.py /tmp/
-RUN python3 /tmp/install-plugins.py
+RUN python3 /tmp/install-plugins.py auto
 
 RUN rm -rf /tmp/install-plugins* /tmp/wordpress-anywhere.patch

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+"""Install WordPress plugins and themes from various locations."""
+
 import atexit
 from collections import namedtuple
 import inspect

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -1,6 +1,26 @@
 #!/usr/bin/python3
 
-"""Install WordPress plugins and themes from various locations."""
+"""Install WordPress plugins and themes from various locations.
+
+Usage:
+
+  install-plugins-and-themes.py auto
+
+    Install all plugins (and in the future, also mu-plugins and themes)
+    into /wp. The list and addresses of plugins to install is determined
+    from the current state of the source code (currently, by
+    interpreting data/plugins/generic/config-lot1.yml out of branch
+    `release2018` in https://github.com/epfl-idevelop/jahia2wp)
+
+  install-plugins-and-themes.py <name> <URL>
+
+    Install one plugin or theme into the current directory. <name> is
+    the name of the subdirectory to create. <URL> can point to a ZIP
+    file, a GitHub URL (possibly pointing to a particular branch and
+    subdirectory), or it can be the string "web" to mean that the
+    plug-in named <name> shall be downloaded from the WordPress plugin
+    repository.
+"""
 
 import atexit
 from collections import namedtuple

--- a/docker/wp-base/install-plugins.py
+++ b/docker/wp-base/install-plugins.py
@@ -354,4 +354,6 @@ if __name__ == '__main__':
         for plugin in Jahia2wp.singleton().plugins():
             plugin.install(WP_IMAGE_INSTALL_DIR)
     else:
-        print("TODO: this doesn't quite work yet.")
+        name = sys.argv[0]
+        url = sys.argv[1]
+        Plugin(name, url).install('.')

--- a/docker/wp-base/install-plugins.py
+++ b/docker/wp-base/install-plugins.py
@@ -191,11 +191,10 @@ class GitHubPlugin(Plugin):
         return GitHubCheckout.is_valid(url)
 
     def __init__(self, name, url):
-        super(GitHubPlugin, self).__init__(name, url)
         self._git = GitHubCheckout(url)
 
     def install(self, target_dir):
-        self._copytree_install(self._git.checkout().source_dir, target_dir)
+        self._copytree_install(self._git.clone().source_dir, target_dir)
 
 
 class WordpressOfficialPlugin(Plugin):

--- a/docker/wp-base/install-plugins.py
+++ b/docker/wp-base/install-plugins.py
@@ -11,6 +11,7 @@ import requests
 import shutil
 from six import string_types
 import subprocess
+import sys
 import tempfile
 import yaml
 from zipfile import ZipFile
@@ -346,5 +347,10 @@ class Jahia2wpLegacyYAMLLoader(yaml.Loader):
 
 
 if __name__ == '__main__':
-    for plugin in Jahia2wp.singleton().plugins():
-        plugin.install()
+    if sys.argv[0].endswith('.py'):
+        sys.argv.pop(0)
+    if sys.argv[0] == 'auto':
+        for plugin in Jahia2wp.singleton().plugins():
+            plugin.install()
+    else:
+        print("TODO: this doesn't quite work yet.")


### PR DESCRIPTION
In order to not reinvent the infrastructure to download subdirectories of GitHub depots (useful e.g. for  installing the wp-theme-2018 in its new directory layout), we open up the use cases for the `install-plugins.py` script.
