### PR TITLE
Create dir for web service call log

### DIFF
--- a/docker/httpd/docker-entrypoint.sh
+++ b/docker/httpd/docker-entrypoint.sh
@@ -28,10 +28,16 @@ VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"
 </VirtualHost>
 EOF
 
-/bin/mkdir -p /webservices/logs
+# Directory to log web services calls. It may already exists if we're on Openshift
+if [ ! -d "/webservices/logs" ]
+then
+    /bin/mkdir -p /webservices/logs
+    /bin/chown www-data: /webservices/logs
+fi
+
 /bin/mkdir -p /srv/${WP_ENV}/logs
 /bin/mkdir -p /srv/${WP_ENV}/jahia2wp
-/bin/chown www-data: /webservices/logs
+
 /bin/chown www-data: /srv/${WP_ENV}
 /bin/chown www-data: /srv/${WP_ENV}/logs
 /bin/chown www-data: /srv/${WP_ENV}/jahia2wp

--- a/docker/httpd/docker-entrypoint.sh
+++ b/docker/httpd/docker-entrypoint.sh
@@ -28,8 +28,10 @@ VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"
 </VirtualHost>
 EOF
 
+/bin/mkdir -p /webservices/logs
 /bin/mkdir -p /srv/${WP_ENV}/logs
 /bin/mkdir -p /srv/${WP_ENV}/jahia2wp
+/bin/chown www-data: /webservices/logs
 /bin/chown www-data: /srv/${WP_ENV}
 /bin/chown www-data: /srv/${WP_ENV}/logs
 /bin/chown www-data: /srv/${WP_ENV}/jahia2wp


### PR DESCRIPTION
Sur OpenShift, les logs des appels aux webservices sont mis dans un dossier de type "emptydir" (`/webservices/logs`) et ce dossier n'existe pas par défaut quand on fait tourner l'image "httpd" localement.
Ajout du nécessaire pour créer le dossier s'il n'existe pas afin que les logs puissent y être écrits.