### PR TITLE
Add inside website error page

### DIFF
--- a/docker/httpd/403/403-inside.php
+++ b/docker/httpd/403/403-inside.php
@@ -1,0 +1,9 @@
+<?php
+
+  // Message shown for the "inside" site error type.
+
+?>
+
+<p>
+  This website access has been restricted by its administrator to some groups and you don't belong to them.
+</p>

--- a/docker/httpd/403/403.php
+++ b/docker/httpd/403/403.php
@@ -34,7 +34,7 @@
   $is_inside_epfl_string = $is_inside_epfl ? "inside EPFL" : "outside EPFL";
 
   // the error types supported by this page
-  $error_types = ["default", "accred"];
+  $error_types = ["default", "accred", "inside"];
 
   // the current error type
   $error_type = "default";


### PR DESCRIPTION
Ajout d'une page d'erreur pour afficher un message différent dans le cas d'une tentative d'accès non-autorisée à la partie "visiteur" d'un site Inside.
Une PR a aussi été faite pour modifier le plugin "accred" afin qu'il puisse rediriger sur cette nouvelle page : https://github.com/epfl-sti/wordpress.plugin.accred/pull/11

Pour le moment, dans le cas d'un accès non autorisé à la partie visiteur d'un site inside, c'est le message d'erreur générique d'accès à la partie admin qui est affiché, à savoir:
![image](https://user-images.githubusercontent.com/11942430/56959763-de237e80-6b4e-11e9-9be4-832d5fec7ec6.png)

Cette PR permet d'afficher un message différent (qui peut être amélioré si besoin):
![image](https://user-images.githubusercontent.com/11942430/56959779-f09db800-6b4e-11e9-8f77-badf47edc372.png)

