### PR TITLE
Remove the `wp_ops_git_branch` variable

### DIFF
--- a/ansible/inventory/prod/group_vars/openshift-namespaces-prod
+++ b/ansible/inventory/prod/group_vars/openshift-namespaces-prod
@@ -6,5 +6,3 @@ ansible_host: prod-ssh-wwp.epfl.ch
 ansible_port: 32222
 ansible_connection: local  # Unless stipulated otherwise in a task
 openshift_namespace: wwp
-
-wp_ops_git_branch: prod

--- a/ansible/inventory/test/group_vars/openshift-namespaces-dev
+++ b/ansible/inventory/test/group_vars/openshift-namespaces-dev
@@ -7,9 +7,6 @@ ansible_port: 32222
 ansible_connection: local  # Unless stipulated otherwise in a task
 openshift_namespace: wwp-test
 
-# TODO: unfork to master
-wp_ops_git_branch: wwp-mgmt-in-openshift
-
 eyaml_keys:
   priv: "/keybase/team/epfl_wp_test/eyaml-privkey.pem"
   pub: "{{ playbook_dir }}/../eyaml/epfl_wp_test.pem"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -12,7 +12,6 @@
     from: "{{ item.from | default(None) }}"
     git:
         repository: "{{ wp_ops_git_uri }}"
-        ref: "{{ wp_ops_git_branch }}"
         path: "{{ item.git_path }}"
   with_items:
     - name: "{{ varnish_image_name }}"

--- a/ansible/roles/wordpress-openshift-namespace/vars/image-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/image-vars.yml
@@ -4,5 +4,3 @@ wp_base_image_name: wp-base
 varnish_image_name: varnish
 
 wp_ops_git_uri: https://github.com/epfl-idevelop/wp-ops
-# wp_ops_git_branch is defined in
-# ../../../hosts-{dev,prod}/group_vars/openshift-namespaces-{dev,prod}


### PR DESCRIPTION
Now that #40 is merged, and we don't build in production anymore, the
branch to build images is just `master`.

Note: the change has already been pushed to the wwp-test namespace (try `oc edit bc/mgmt`, notice the lack of `ref:`)