### PR TITLE
Change FROM to allow local build

### DIFF
--- a/docker/cronjob/Dockerfile
+++ b/docker/cronjob/Dockerfile
@@ -1,3 +1,6 @@
-FROM epflidevelop/os-wp-mgmt
+# This line is used only for local build (docker-compose build).
+# When using OpenShift environment, we can configure builds to use an existing image stream
+# which is, in our case : wwp/mgmt:prod
+FROM jahia2wp_wp-mgmt
 
 USER www-data

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -1,4 +1,7 @@
-FROM epflidevelop/os-wp-base
+# This line is used only for local build (docker-compose build).
+# When using OpenShift environment, we can configure builds to use an existing image stream
+# which is, in our case : wwp-test/wp-base:latest
+FROM jahia2wp_wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     apache2 \

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -1,4 +1,7 @@
-FROM epflidevelop/os-wp-base
+# This line is used only for local build (docker-compose build).
+# When using OpenShift environment, we can configure builds to use an existing image stream
+# which is, in our case : wwp-test/wp-base:latest
+FROM jahia2wp_wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     bash-completion \

--- a/docker/mgmt/php.ini
+++ b/docker/mgmt/php.ini
@@ -1,0 +1,3 @@
+;; For EPFL stats mu-plugin. Allows to access APC using CLI (WP-CLI)
+apc.enabled = 1
+apc.enable_cli = 1


### PR DESCRIPTION
Changement de quelques éléments pour permettre le build en local.
PR en lien avec:
- https://github.com/epfl-idevelop/jahia2wp/pull/984 
- https://github.com/epfl-idevelop/jahia2wp/pull/985 

On change les directives `FROM` des Dockerfile afin de ne plus utilisé les images dans DockerHub (c'est ce qui a été défini récemment). Changer ces directives permettra de construire les images en local pour le développement.
Du côté d'OpenShift, rien ne change car ce directives `FROM` sont overridées par la configuration dans les builds où on spécifie explicitement quel "Image Stream" utiliser. Exemple pour `mgmt` : 
![image](https://user-images.githubusercontent.com/11942430/57227432-ad8d8a00-7011-11e9-9f40-1dbd3a37491f.png)

Une petite documentation a été faite sur Confluence pour les relations entre les images: https://sico.epfl.ch:8443/pages/viewpage.action?pageId=92210816