### PR TITLE
Update Docker image's Polylang to latest version

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -88,7 +88,10 @@ ADD wordpress-anywhere.patch /tmp/
 RUN cd /; git apply < /tmp/wordpress-anywhere.patch
 
 ADD install-plugins-and-themes.py /tmp/
+# Get all plugins and themes ("auto" mode) from the jahia2wp manifest:
 RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
+# jahia2wp uses an ancient version of Polylang (for reasons that have
+# no bearing on the task at hand). Upgrade it:
 RUN set -e -x;                                                           \
     cd /wp/wp-content/plugins;                                           \
     rm -rf polylang;                                                     \

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -88,6 +88,10 @@ ADD wordpress-anywhere.patch /tmp/
 RUN cd /; git apply < /tmp/wordpress-anywhere.patch
 
 ADD install-plugins-and-themes.py /tmp/
-RUN set -x; python3 /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
+RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
+RUN set -e -x;                                                           \
+    cd /wp/wp-content/plugins;                                           \
+    rm -rf polylang;                                                     \
+    /tmp/install-plugins-and-themes.py polylang wordpress.org/plugins
 
 RUN rm -rf /tmp/install-plugins* /tmp/wordpress-anywhere.patch

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """Install WordPress plugins and themes from various locations."""
 
@@ -37,9 +37,9 @@ Usage:
     Install one plugin or theme into the current directory. <name> is
     the name of the subdirectory to create. <URL> can point to a ZIP
     file, a GitHub URL (possibly pointing to a particular branch and
-    subdirectory), or it can be the string "web" to mean that the
-    plug-in named <name> shall be downloaded from the WordPress plugin
-    repository.
+    subdirectory), or it can be the string "web" or the string
+    "wordpress.org/plugins", both meaning that the plug-in named
+    <name> shall be downloaded from the WordPress plugin repository.
 
 Options:
 
@@ -249,7 +249,7 @@ class WordpressOfficialPlugin(Plugin):
     """A plug-in to download from the official plug-in repository."""
     @classmethod
     def handles(cls, url):
-        return url == 'web'
+        return url == 'web' or url == 'wordpress.org/plugins'
 
     @property
     def api_struct(self):


### PR DESCRIPTION
The reason epfl-idevelop/jahia2wp has a
data/plugins/generic/polylang/polylang.zip stuck in the past is so
that things work when importing a multilingual site converted from
Jahia. Since 1) we are no longer going to do that and 2) the version
of Polylang in /wp/ has no impact whatsoever on the jahia2wp Python
script, we want to override config-lot1.yml for that one plug-in.

- Make install-plugins-and-themes.py executable

- Invoke it once more in the Dockerfile for Polylang

- Make it so "wordpress.org/plugins" is a synonym to "web" as a source
  URL for a plug-in