### PR TITLE
Ensure SSH daemon starts, even if in dev mode

### DIFF
--- a/docker/mgmt/docker-entrypoint.sh
+++ b/docker/mgmt/docker-entrypoint.sh
@@ -25,11 +25,13 @@ iwait() {
 
 ################################################
 
+/usr/sbin/sshd -D &
+SSHD_PID=$!
+
 if [ -d "$SECRETS_DIR" ]; then
     sync_keys
 
-    /usr/sbin/sshd -D &
-    SSHD_PID=$!
+
     while iwait -t 300 -r /var/lib/secrets/ssh; do
         sync_keys
         kill -HUP $SSHD_PID  # Will fail, and cause the whole script to exit,


### PR DESCRIPTION
Déplacement de la commande qui démarre le deamon SSH dans `mgmt` car sinon, impossible de faire du debug en mode développement.