### PR TITLE
Inventory report with Ansible with plug-in versions

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -134,8 +134,7 @@ sub flatten_wordpresses {
 
 sub as_ansible_hostvars {
   my $wp = {@_};
-  $wp->{ansible_python_interpreter} = "/srv/" . $wp->{wp_env} .
-    "/venv/bin/python";
+  $wp->{ansible_python_interpreter} = "/usr/bin/python3";
   my $retval = {};
   while(my ($k, $v) = each %$wp) {
     next unless $k =~ m/^(ssh|wp|ansible)_/;

--- a/ansible/inventory/test/group_vars/charte-wordpresses
+++ b/ansible/inventory/test/group_vars/charte-wordpresses
@@ -4,5 +4,6 @@
 ansible_host: test-ssh-wwp.epfl.ch
 ansible_port: 32222
 ansible_user: www-data
+ansible_python_interpreter: /usr/bin/python3
 wp_env: lvenries
 wp_hostname: charte-wp.epfl.ch

--- a/ansible/inventory/test/group_vars/migration-int-wordpresses
+++ b/ansible/inventory/test/group_vars/migration-int-wordpresses
@@ -4,5 +4,6 @@
 ansible_host: test-ssh-wwp.epfl.ch
 ansible_port: 32222
 ansible_user: www-data
+ansible_python_interpreter: /usr/bin/python3
 wp_hostname: migration-wp.epfl.ch
 wp_env: int

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -134,8 +134,7 @@ sub flatten_wordpresses {
 
 sub as_ansible_hostvars {
   my $wp = {@_};
-  $wp->{ansible_python_interpreter} = "/srv/" . $wp->{wp_env} .
-    "/venv/bin/python";
+  $wp->{ansible_python_interpreter} = "/usr/bin/python3";
   my $retval = {};
   while(my ($k, $v) = each %$wp) {
     next unless $k =~ m/^(ssh|wp|ansible)_/;

--- a/ansible/playbooks/wordpress-main.yml
+++ b/ansible/playbooks/wordpress-main.yml
@@ -2,7 +2,7 @@
 
 - name: Initial checks
   hosts: all
-  gather_facts: no   # Not yet
+  gather_facts: no    # Ansible facts are useless for this play
   tasks:
     - name: Check Ansible version
       run_once: true
@@ -18,7 +18,7 @@
 # them on standard output)
 - name: WordPress instances
   hosts: all-wordpresses
-  gather_facts: no   # Delayed, see ../roles/wordpress-instance/tasks/setup.yml
+  gather_facts: no   # But see ../roles/wordpress-instance/tasks/facts.yml
   roles:
     - role: ../roles/wordpress-instance
 
@@ -26,6 +26,6 @@
 # namespaces, not hosts
 - name: OpenShift namespaces
   hosts: all-openshift-namespaces
-  gather_facts: no   # Useless here, afaict
+  gather_facts: no    # Ansible facts are useless for this play
   roles:
     - role: ../roles/wordpress-openshift-namespace

--- a/ansible/roles/wordpress-instance/defaults/main/report-vars.yml
+++ b/ansible/roles/wordpress-instance/defaults/main/report-vars.yml
@@ -1,0 +1,3 @@
+# Where to output the report made by `wpsible -t reportcsv`
+wpsible_cwd: "."
+report_csv_out: "{{ wpsible_cwd }}/report.csv"

--- a/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_report.py
+++ b/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_report.py
@@ -1,0 +1,330 @@
+"""CSV report on a bunch of WordPress instances."""
+
+import csv as CSV
+import io
+import sys
+
+EXAMPLES = """
+- name: CSV inventory report
+  local_action:
+    module: copy
+    dest: "./report.csv"
+    content: '{{ hostvars | wp_inventory_csv_report }}'
+"""
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'wp_inventory_csv_report': self.make_report
+        }
+
+    def make_report(self, hostvars, with_header_line=True):
+        if (sys.version_info > (3, 0)):
+            output = io.StringIO()
+        else:
+            # https://stackoverflow.com/a/13120279/435004
+            output = io.BytesIO()
+
+        m = ReportModel(hostvars)
+        fields = ['name'] + ['plugin_version_%s' % n
+                             for n in m.all_plugin_names]
+
+        csv = CSV.DictWriter(output, fieldnames=fields)
+        csv.writeheader()
+
+        for name, host in m.iterhosts():
+            csvrow = {'name': name}
+            for p in host.plugins:
+                csvrow['plugin_version_%s' % p.name] = p.version
+            csv.writerow(csvrow)
+
+        return output.getvalue()
+
+
+class memoize:
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def __call__(self, owner):
+        cache_attr = '_memoized_%s' % self._wrapped.__name__
+        if not hasattr(owner, cache_attr):
+            setattr(owner, cache_attr, self._wrapped(owner))
+        return getattr(owner, cache_attr)
+
+
+def memoize_property(wat):
+    return property(memoize(wat))
+
+
+class ReportModel(object):
+    def __init__(self, hostvars):
+        self.hostvars = hostvars
+
+    @memoize_property
+    def all_plugin_names(self):
+        return sorted(set(p.name for _unused, h in self.iterhosts()
+                          for p in h.plugins))
+
+    def iterhosts(self):
+        for host, vars in self.hostvars.items():
+            yield host, self.Host(host, vars["ansible_facts"]["ansible_local"])
+
+    class Host(object):
+        def __init__(self, name, vars):
+            self.name = name
+            self.vars = vars
+            self.plugins = []
+            self.mu_plugins = []
+
+            for wp_plugin_list_entry in self.vars["wp_plugin_list"]:
+                for subclass, bucket in (
+                        (self.Plugin, self.plugins),
+                        (self.MustUsePlugin, self.mu_plugins)):
+                    if subclass.fits(wp_plugin_list_entry):
+                        bucket.append(
+                            subclass(wp_plugin_list_entry))
+
+        class PluginBase(object):
+            def __init__(self, wp_plugin_list_entry):
+                assert self.fits(wp_plugin_list_entry)
+                self.name    = wp_plugin_list_entry["name"]     # noqa
+                self.version = wp_plugin_list_entry["version"]
+
+        class Plugin(PluginBase):
+            @classmethod
+            def fits(cls, wp_plugin_list_entry):
+                return wp_plugin_list_entry["status"] == "active"
+
+        class MustUsePlugin(PluginBase):
+            @classmethod
+            def fits(cls, wp_plugin_list_entry):
+                return wp_plugin_list_entry["status"] == "must-use"
+
+
+
+################################  TEST SUITE ###########################
+if __name__ == '__main__':
+    hostvars = {
+        "www-ventil2": {
+            "ansible_facts": {
+                "ansible_local": {
+                    "wp_is_installed": "true",
+                    "wp_is_symlinked": "true",
+                    "wp_plugin_list": [
+                        {
+                            "name": "cache-control",
+                            "status": "active",
+                            "update": "none",
+                            "version": "2.2.3"
+                        },
+                        {
+                            "name": "epfl",
+                            "status": "active",
+                            "update": "none",
+                            "version": "1.24"
+                        },
+                        {
+                            "name": "epfl-404",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.3"
+                        },
+                        {
+                            "name": "EPFL-Share",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.1"
+                        },
+                        {
+                            "name": "accred",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.13 (vpsi)"
+                        },
+                        {
+                            "name": "EPFL-Content-Filter",
+                            "status": "inactive",
+                            "update": "none",
+                            "version": "0.1.0"
+                        },
+                        {
+                            "name": "EPFL-settings",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.6"
+                        },
+                        {
+                            "name": "epfl-infoscience",
+                            "status": "active",
+                            "update": "none",
+                            "version": "1.5"
+                        },
+                        {
+                            "name": "tequila",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.15 (vpsi)"
+                        },
+                        {
+                            "name": "ewww-image-optimizer",
+                            "status": "active",
+                            "update": "none",
+                            "version": "4.7.4"
+                        },
+                        {
+                            "name": "feedzy-rss-feeds",
+                            "status": "active",
+                            "update": "none",
+                            "version": "3.3.6"
+                        },
+                        {
+                            "name": "mainwp-child",
+                            "status": "active",
+                            "update": "none",
+                            "version": "3.5.7"
+                        },
+                        {
+                            "name": "wp-nested-pages",
+                            "status": "active",
+                            "update": "none",
+                            "version": "3.0.11"
+                        },
+                        {
+                            "name": "pdfjs-viewer-shortcode",
+                            "status": "active",
+                            "update": "none",
+                            "version": "1.3"
+                        },
+                        {
+                            "name": "polylang",
+                            "status": "active",
+                            "update": "none",
+                            "version": "2.5.3"
+                        },
+                        {
+                            "name": "varnish-http-purge",
+                            "status": "active",
+                            "update": "none",
+                            "version": "4.8.1"
+                        },
+                        {
+                            "name": "remote-content-shortcode",
+                            "status": "active",
+                            "update": "none",
+                            "version": "1.4.3"
+                        },
+                        {
+                            "name": "shortcode-ui",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.7.4"
+                        },
+                        {
+                            "name": "shortcode-ui-richtext",
+                            "status": "active",
+                            "update": "none",
+                            "version": "1.3"
+                        },
+                        {
+                            "name": "simple-sitemap",
+                            "status": "active",
+                            "update": "none",
+                            "version": "3.0"
+                        },
+                        {
+                            "name": "svg-support",
+                            "status": "active",
+                            "update": "none",
+                            "version": "2.3.15"
+                        },
+                        {
+                            "name": "tinymce-advanced",
+                            "status": "active",
+                            "update": "none",
+                            "version": "5.2.0"
+                        },
+                        {
+                            "name": "very-simple-meta-description",
+                            "status": "active",
+                            "update": "none",
+                            "version": "5.4"
+                        },
+                        {
+                            "name": "wordpress-importer",
+                            "status": "active",
+                            "update": "none",
+                            "version": "0.6.4"
+                        },
+                        {
+                            "name": "wp-media-folder",
+                            "status": "active",
+                            "update": "available",
+                            "version": "4.7.11"
+                        },
+                        {
+                            "name": "EPFL_stats_loader",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "1.5"
+                        },
+                        {
+                            "name": "EPFL_custom_editor_menu",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.0.1"
+                        },
+                        {
+                            "name": "EPFL_disable_updates_automatic",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.0.1"
+                        },
+                        {
+                            "name": "EPFL_disable_comments",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.2"
+                        },
+                        {
+                            "name": "EPFL_enable_updates_automatic",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.0.1"
+                        },
+                        {
+                            "name": "epfl-functions",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.0.7"
+                        },
+                        {
+                            "name": "EPFL_google_analytics_hook",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "1.0"
+                        },
+                        {
+                            "name": "EPFL_installs_locked",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.0.4"
+                        },
+                        {
+                            "name": "EPFL_quota_loader",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "0.4"
+                        },
+                        {
+                            "name": "EPFL_jahia_redirect",
+                            "status": "must-use",
+                            "update": "none",
+                            "version": "1.3"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    print(FilterModule().make_report(hostvars, with_header_line=True))

--- a/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_report.py
+++ b/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_report.py
@@ -105,8 +105,7 @@ class ReportModel(object):
                 return wp_plugin_list_entry["status"] == "must-use"
 
 
-
-################################  TEST SUITE ###########################
+# TEST SUITE #########################################################
 if __name__ == '__main__':
     hostvars = {
         "www-ventil2": {

--- a/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_reports.py
+++ b/ansible/roles/wordpress-instance/filter_plugins/wp_inventory_csv_reports.py
@@ -28,22 +28,18 @@ WELL_KNOWN_GROUPS = [
 class FilterModule(object):
     def filters(self):
         return {
-            'wp_inventory_csv_report': self.make_report
+            'wp_plugin_versions_csv_report': self.plugin_versions_report
         }
 
-    def make_report(self, hostvars, with_header_line=True):
-        if (sys.version_info > (3, 0)):
-            output = io.StringIO()
-        else:
-            # https://stackoverflow.com/a/13120279/435004
-            output = io.BytesIO()
-
+    def plugin_versions_report(self, hostvars, with_header_line=True):
         m = ReportModel(hostvars)
         fields = ['name', 'group'] + ['plugin_version_%s' % n
                                       for n in m.all_plugin_names]
 
+        output = _StringIO()
         csv = CSV.DictWriter(output, fieldnames=fields)
-        csv.writeheader()
+        if with_header_line:
+            csv.writeheader()
 
         for name, host in m.iterhosts():
             csvrow = {'name': name, 'group': host.group}
@@ -52,6 +48,16 @@ class FilterModule(object):
             csv.writerow(csvrow)
 
         return output.getvalue()
+
+#############################################################################
+
+
+def _StringIO():
+    if (sys.version_info > (3, 0)):
+        return io.StringIO()
+    else:
+        # https://stackoverflow.com/a/13120279/435004
+        return io.BytesIO()
 
 
 class memoize:

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -49,7 +49,26 @@
       WP_SYMLINKED_SCRIPT
 
       make_fact_script wp_plugin_list <<'WP_PLUGINS_SCRIPT'
-      wp --path="{{ wp_dir }}" plugin list --format=json | jq .
+      maybe_json="$(wp --path="{{ wp_dir }}" plugin list --format=json)"
+      if echo "$maybe_json" | jq -e . ; then
+        exit 0
+      else
+        case "$?" in
+          4) : ;;  # Malformed JSON - Continues below
+          *) exit 0 ;;
+        esac
+      fi
+
+      python3 - <<PYTHON_MALFORMED_JSON
+
+      import json,sys
+      bad_json = """$maybe_json"""
+      print(json.dumps({
+        "_error": "\`wp --path={{ wp_dir }} plugin list --format=json\` produced unparseable JSON",
+        "_output_excerpt": bad_json[:160]
+      }))
+      PYTHON_MALFORMED_JSON
+
       WP_PLUGINS_SCRIPT
 
       echo "$factsdir" >&3

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -1,26 +1,81 @@
 # Collect WordPress-specific Ansible facts
 
-- name: Inspect WordPress installed files
-  stat:
-    path: "{{ item }}"
-  with_items:
-    - "{{ wp_path_config_php }}"
-    - "{{ wp_path_wpadmin }}"
-  register: _wp_stat
+# The TL;DR of this charade is that Ansible's set_fact, well, doesn't.
+# You do have to go through a fact script on the remote end if you
+# want to share facts across the inventory (through
+# hostvars[some_hostname]["ansible_facts"]["ansible_local"]). See
+# https://medium.com/@jezhalford/ansible-custom-facts-1e1d1bf65db8
+- name: Fact directory
+  tags: always
+  # Speed matters here - Since we must make the facts available to the
+  # rest of the Ansible code no matter the tags (that's what tags:
+  # always means on the line above), we must strive to keep the
+  # execution time small, lest even the simple tasks get penalized.
+  # That's why we must create the facts.d and its inhabiting scripts
+  # in the same task.
+  shell: |
+    set -e -x
+    exec 3>&1 >&2
 
-- name: Inspect WordPress plug-ins
-  shell: wp --path="{{ wp_dir }}" plugin list --format=json
-  register: _wp_plugin_list_json
+    factsdir="$(mktemp -d ansible-wordpress-XXXXXX-facts.d)"
+    cleanup_on_error() {
+      [ -n "$factsdir" ] && rm -rf "$factsdir"
+    }
+    trap cleanup_on_error EXIT INT QUIT HUP
+
+    make_fact_script() {
+      cat >"$factsdir/$1.fact"
+      chmod 755 "$1"
+    }
+
+    make_fact_script wp_is_installed <<WP_INSTALLED_SCRIPT
+    if [ -f "{{ wp_path_config_php }}" ]; then
+      echo true
+    else
+      echo false
+    fi
+    WP_INSTALLED_SCRIPT
+
+    make_fact_script wp_is_symlinked <<WP_SYMLINKED_SCRIPT
+    if [ -f "{{ wp_path_wpadmin }}" ]; then
+      echo true
+    else
+      echo false
+    fi
+    WP_SYMLINKED_SCRIPT
+
+    make_fact_script wp_plugin_list <<WP_PLUGINS_SCRIPT
+    wp --path="{{ wp_dir }}" plugin list --format=json
+    WP_PLUGINS_SCRIPT
+
+    echo "$factsdir" >&3
+    unset factsdir  # So that cleanup_on_error() won't
+  register: _facts_dir
   changed_when: false
-  failed_when: false
 
-- set_fact:
-    wp_is_installed: "{{ _wp_stat.results[0].stat.exists }}"
-    wp_is_symlinked: "{{ _wp_stat.results[1].stat.islnk }}"
-    wp_plugin_list: >-
-      {{ (_wp_plugin_list_json.stdout if _wp_plugin_list_json.rc == 0
-                                      else '[]')
-         | from_json }}
+- setup:
+    gather_subset: "!all"    # pronounced "f..k-all", as we only
+                             # care about our own facts
+    fact_path: "{{ _facts_tmpdir.path }}"
+  tags: always
+
+############# Debugging support #############################
+# Pass -t _debug_facts on the command line to enable this section
+
+- tags: ["never", "_debug_facts"]
+  shell: |
+    "{{ _facts_tmpdir.path }}/wordpress.fact"
+  register: _run_fact_scripts_directly
+  changed_when: false
+
+- tags: ["never", "_debug_facts"]
+  debug:
+    msg: "{{ _run_fact_scripts_directly }}"
+
+- tags: ["never", "_debug_facts"]
+  debug:
+    msg:
+      - "{{ hostvars[inventory_hostname] }}"
 
 - tags: ["never", "_debug_facts"]
   debug:
@@ -28,3 +83,16 @@
       - "{{ wp_is_installed }}"
       - "{{ wp_is_symlinked }}"
       - "{{ wp_plugin_list }}"
+
+
+############# All done, clean up #############################
+
+# That's perhaps a matter of taste but I'd rather have to create and
+# clean up all these yadda-yadda-facts.d directories within a few
+# seconds, than have them litter the entire serving tree.
+- name: Delete fact directory
+  tags: always
+  file:
+    path: "{{ _facts_dir.stdout }}"
+    state: absent
+  changed_when: false

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -66,30 +66,27 @@
   tags: always
 
 ############# Debugging support #############################
-# Pass -t _debug_facts on the command line to enable this section
+# Pass `-t _debug_facts` or `-t _debug2_facts` on the command line to
+# enable this section
 
-- tags: ["never", "_debug_facts"]
+- tags: ["never", "_debug2_facts"]
+  name: Run fact scripts directly for debug
   shell: |
-    "{{ _facts_dir.stdout }}/wordpress.fact"
+    set -e -x
+    for script in {{ _facts_dir.stdout }}/*.fact; do sh -x $script; done
   register: _run_fact_scripts_directly
   changed_when: false
 
-- tags: ["never", "_debug_facts"]
+- tags: ["never", "_debug2_facts"]
+  name: Result of above (_run_fact_scripts_directly)
   debug:
     msg: "{{ _run_fact_scripts_directly }}"
 
-- tags: ["never", "_debug_facts"]
+- tags: ["never", "_debug_facts", "_debug2_facts"]
+  name: Debug ansible_facts
   debug:
     msg:
-      - "{{ hostvars[inventory_hostname] }}"
-
-- tags: ["never", "_debug_facts"]
-  debug:
-    msg:
-      - "{{ wp_is_installed }}"
-      - "{{ wp_is_symlinked }}"
-      - "{{ wp_plugin_list }}"
-
+      - '{{ ansible_facts }}'
 
 ############# All done, clean up #############################
 
@@ -97,7 +94,7 @@
 # clean up all these yadda-yadda-facts.d directories within a few
 # seconds, than have them litter the entire serving tree.
 - name: Delete fact directory
-  tags: always
+  when: '"_debug2_facts" not in ansible_run_tags'
   file:
     path: "{{ _facts_dir.stdout }}"
     state: absent

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -60,8 +60,14 @@
   changed_when: false
 
 - setup:
-    gather_subset: "!all"    # pronounced "f..k-all", as we only
-                             # care about our own facts
+    gather_subset:
+      # "Standard" facts are just noise to us.
+      # ⚠ Running `setup` with a limited `gather_subset` won't clean
+      # up the fact cache for you, which can be confusing under `-t
+      # _debug_facts` - Try `rm -rf ~/.ansible/facts`
+      - "!all"
+      - "!min"
+      - local
     fact_path: "{{ _facts_dir.stdout }}"
   tags: always
 

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -49,7 +49,7 @@
       WP_SYMLINKED_SCRIPT
 
       make_fact_script wp_plugin_list <<WP_PLUGINS_SCRIPT
-      wp --path="{{ wp_dir }}" plugin list --format=json
+      wp --path="{{ wp_dir }}" plugin list --format=json | jq .
       WP_PLUGINS_SCRIPT
 
       echo "$factsdir" >&3

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -50,6 +50,7 @@
 
     echo "$factsdir" >&3
     unset factsdir  # So that cleanup_on_error() won't
+    # '  # https://github.com/ansible/ansible/issues/28674 - Sad
   register: _facts_dir
   changed_when: false
 

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -32,7 +32,7 @@
         if ! chmod 755 "$scriptname"; then echo "OUCH"; fi
       }
 
-      make_fact_script wp_is_installed <<WP_INSTALLED_SCRIPT
+      make_fact_script wp_is_installed <<'WP_INSTALLED_SCRIPT'
       if [ -f "{{ wp_path_config_php }}" ]; then
         echo true
       else
@@ -40,7 +40,7 @@
       fi
       WP_INSTALLED_SCRIPT
 
-      make_fact_script wp_is_symlinked <<WP_SYMLINKED_SCRIPT
+      make_fact_script wp_is_symlinked <<'WP_SYMLINKED_SCRIPT'
       if [ -f "{{ wp_path_wpadmin }}" ]; then
         echo true
       else
@@ -48,7 +48,7 @@
       fi
       WP_SYMLINKED_SCRIPT
 
-      make_fact_script wp_plugin_list <<WP_PLUGINS_SCRIPT
+      make_fact_script wp_plugin_list <<'WP_PLUGINS_SCRIPT'
       wp --path="{{ wp_dir }}" plugin list --format=json | jq .
       WP_PLUGINS_SCRIPT
 

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -7,57 +7,62 @@
 # https://medium.com/@jezhalford/ansible-custom-facts-1e1d1bf65db8
 - name: Fact directory
   tags: always
-  # Speed matters here - Since we must make the facts available to the
-  # rest of the Ansible code no matter the tags (that's what tags:
-  # always means on the line above), we must strive to keep the
-  # execution time small, lest even the simple tasks get penalized.
-  # That's why we must create the facts.d and its inhabiting scripts
-  # in the same task.
-  shell: |
-    set -e -x
-    exec 3>&1 >&2
+  # Speed matters here, when running short tasks (with -t) - We don't
+  # want (mandatory) facts collection time to dominate the execution
+  # time in that case, so we want to populate the whole facts.d
+  # directory in a single task.
+  shell:
+    # Must use undocumented "cmd" parameter to ward off spurious
+    # indents that break here-docs - See
+    # https://stackoverflow.com/a/40230416/435004
+    cmd: |
+      set -e -x
+      exec 3>&1 >&2
 
-    factsdir="$(mktemp -d ansible-wordpress-XXXXXX-facts.d)"
-    cleanup_on_error() {
-      [ -n "$factsdir" ] && rm -rf "$factsdir"
-    }
-    trap cleanup_on_error EXIT INT QUIT HUP
+      factsdir="$(mktemp -d "/tmp/wordpress-XXXXXX-facts.d")"
+      cleanup_on_error() {
+        if [ -n "$factsdir" ]; then rm -rf "$factsdir"; fi
+      }
+      trap cleanup_on_error EXIT INT QUIT HUP
 
-    make_fact_script() {
-      cat >"$factsdir/$1.fact"
-      chmod 755 "$1"
-    }
+      make_fact_script() {
+        local scriptname
+        scriptname="$factsdir/$1.fact"
+        (echo "#!/bin/sh"; echo) > "$scriptname"
+        cat >> "$scriptname"
+        if ! chmod 755 "$scriptname"; then echo "OUCH"; fi
+      }
 
-    make_fact_script wp_is_installed <<WP_INSTALLED_SCRIPT
-    if [ -f "{{ wp_path_config_php }}" ]; then
-      echo true
-    else
-      echo false
-    fi
-    WP_INSTALLED_SCRIPT
+      make_fact_script wp_is_installed <<WP_INSTALLED_SCRIPT
+      if [ -f "{{ wp_path_config_php }}" ]; then
+        echo true
+      else
+        echo false
+      fi
+      WP_INSTALLED_SCRIPT
 
-    make_fact_script wp_is_symlinked <<WP_SYMLINKED_SCRIPT
-    if [ -f "{{ wp_path_wpadmin }}" ]; then
-      echo true
-    else
-      echo false
-    fi
-    WP_SYMLINKED_SCRIPT
+      make_fact_script wp_is_symlinked <<WP_SYMLINKED_SCRIPT
+      if [ -f "{{ wp_path_wpadmin }}" ]; then
+        echo true
+      else
+        echo false
+      fi
+      WP_SYMLINKED_SCRIPT
 
-    make_fact_script wp_plugin_list <<WP_PLUGINS_SCRIPT
-    wp --path="{{ wp_dir }}" plugin list --format=json
-    WP_PLUGINS_SCRIPT
+      make_fact_script wp_plugin_list <<WP_PLUGINS_SCRIPT
+      wp --path="{{ wp_dir }}" plugin list --format=json
+      WP_PLUGINS_SCRIPT
 
-    echo "$factsdir" >&3
-    unset factsdir  # So that cleanup_on_error() won't
-    # '  # https://github.com/ansible/ansible/issues/28674 - Sad
+      echo "$factsdir" >&3
+      unset factsdir  # So that cleanup_on_error() won't
+      # '  # https://github.com/ansible/ansible/issues/28674 - Sad
   register: _facts_dir
   changed_when: false
 
 - setup:
     gather_subset: "!all"    # pronounced "f..k-all", as we only
                              # care about our own facts
-    fact_path: "{{ _facts_tmpdir.path }}"
+    fact_path: "{{ _facts_dir.stdout }}"
   tags: always
 
 ############# Debugging support #############################
@@ -65,7 +70,7 @@
 
 - tags: ["never", "_debug_facts"]
   shell: |
-    "{{ _facts_tmpdir.path }}/wordpress.fact"
+    "{{ _facts_dir.stdout }}/wordpress.fact"
   register: _run_fact_scripts_directly
   changed_when: false
 

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -1,16 +1,4 @@
-# Ansible pre-configuration and fact gathering
-#
-# The name is to be understood in the Ansible sense (like the `setup`
-# task); the tasks in this file don't actually set up or mutate
-# anything.
-
-- name: Ansible pre-configuration
-  set_fact:
-    ansible_user: www-data
-    ansible_python_interpreter: "/srv/{{wp_env}}/venv/bin/python"
-
-- name: Gathering facts (delayed after Ansible pre-configuration)
-  setup:
+# Collect WordPress-specific Ansible facts
 
 - name: Inspect WordPress installed files
   stat:
@@ -34,7 +22,7 @@
                                       else '[]')
          | from_json }}
 
-- tags: ["never", "_debug_setup"]
+- tags: ["never", "_debug_facts"]
   debug:
     msg:
       - "{{ wp_is_installed }}"

--- a/ansible/roles/wordpress-instance/tasks/facts.yml
+++ b/ansible/roles/wordpress-instance/tasks/facts.yml
@@ -6,7 +6,6 @@
 # hostvars[some_hostname]["ansible_facts"]["ansible_local"]). See
 # https://medium.com/@jezhalford/ansible-custom-facts-1e1d1bf65db8
 - name: Fact directory
-  tags: always
   # Speed matters here, when running short tasks (with -t) - We don't
   # want (mandatory) facts collection time to dominate the execution
   # time in that case, so we want to populate the whole facts.d
@@ -69,27 +68,28 @@
       - "!min"
       - local
     fact_path: "{{ _facts_dir.stdout }}"
-  tags: always
 
 ############# Debugging support #############################
-# Pass `-t _debug_facts` or `-t _debug2_facts` on the command line to
-# enable this section
+# Pass `-t facts,_debug_facts` or `-t facts,_debug2_facts` on the
+# command line to enable this section
 
-- tags: ["never", "_debug2_facts"]
-  name: Run fact scripts directly for debug
+- name: Run fact scripts directly for debug
+  when: '"_debug2_facts" in ansible_run_tags'
   shell: |
     set -e -x
     for script in {{ _facts_dir.stdout }}/*.fact; do sh -x $script; done
   register: _run_fact_scripts_directly
   changed_when: false
 
-- tags: ["never", "_debug2_facts"]
-  name: Result of above (_run_fact_scripts_directly)
+- name: Result of above (_run_fact_scripts_directly)
+  when: '"_debug2_facts" in ansible_run_tags'
   debug:
     msg: "{{ _run_fact_scripts_directly }}"
 
-- tags: ["never", "_debug_facts", "_debug2_facts"]
-  name: Debug ansible_facts
+- name: Debug ansible_facts
+  when: >
+    "_debug_facts" in ansible_run_tags or
+    "_debug2_facts" in ansible_run_tags
   debug:
     msg:
       - '{{ ansible_facts }}'

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -5,8 +5,11 @@
 # Variables:: (in addition to those defined or documented in
 #              ../vars/*.yml)
 
-- include_vars: wp-destructive.yml
-  tags: always
+- include_vars: wp-destructive.yml   # For wp_can
+  tags:
+    - symlink
+    - unsymlink
+    - config
 
 - name: WordPress facts
   import_tasks: facts.yml
@@ -82,6 +85,7 @@
   tags:
     - never
     - reportcsv
+  run_once: true
   local_action:
     module: copy
     dest: "./report.csv"

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -8,8 +8,14 @@
 - include_vars: wp-destructive.yml
   tags: always
 
+- name: Ansible pre-configuration
+  tags: always
+  set_fact:
+    ansible_user: www-data
+    ansible_python_interpreter: "/srv/{{wp_env}}/venv/bin/python"
+
 - name: WordPress facts
-  import_tasks: setup.yml
+  import_tasks: facts.yml
   tags: always
 
 - name: "Backup"

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -18,7 +18,7 @@
   import_tasks: facts.yml
   tags: always
 
-- name: "Backup"
+- name: Backup
   import_tasks: "backup.yml"
   tags:
     - never  # That is, skip unless "-t backup" or "-t wipe" is
@@ -26,7 +26,7 @@
     - wipe
     - backup
 
-- name: "Wipe"
+- name: Wipe
   import_tasks: "wipe.yml"
   tags:
     - never

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -88,5 +88,5 @@
   run_once: true
   local_action:
     module: copy
-    dest: "./report.csv"
+    dest: "{{ report_csv_out }}"
     content: '{{ hostvars | wp_inventory_csv_report }}'

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -81,7 +81,7 @@
     - never
     - undump
 
-- name: CSV inventory report
+- name: CSV plug-in versions report
   tags:
     - never
     - reportcsv
@@ -89,4 +89,4 @@
   local_action:
     module: copy
     dest: "{{ report_csv_out }}"
-    content: '{{ hostvars | wp_inventory_csv_report }}'
+    content: '{{ hostvars | wp_plugin_versions_csv_report }}'

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -8,12 +8,6 @@
 - include_vars: wp-destructive.yml
   tags: always
 
-- name: Ansible pre-configuration
-  tags: always
-  set_fact:
-    ansible_user: www-data
-    ansible_python_interpreter: "/srv/{{wp_env}}/venv/bin/python"
-
 - name: WordPress facts
   import_tasks: facts.yml
   tags: always

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -69,8 +69,10 @@
       tags: ["config"]
 
 ################################
-# "Ventilation"-related tasks
+# Special-purpose tasks
 ################################
+
+# "Ventilation"-related
 - name: "Dump to WXR for ventilation"
   import_tasks: "dump.yml"
   tags:
@@ -81,3 +83,12 @@
   tags:
     - never
     - undump
+
+- name: CSV inventory report
+  tags:
+    - never
+    - reportcsv
+  local_action:
+    module: copy
+    dest: "./report.csv"
+    content: '{{ hostvars | wp_inventory_csv_report }}'

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: WordPress facts
   import_tasks: facts.yml
-  tags: always
+  tags: facts
 
 - name: Backup
   import_tasks: "backup.yml"

--- a/ansible/roles/wordpress-instance/tasks/setup.yml
+++ b/ansible/roles/wordpress-instance/tasks/setup.yml
@@ -1,4 +1,8 @@
-# Ansible pre-configuration and fact gathering 
+# Ansible pre-configuration and fact gathering
+#
+# The name is to be understood in the Ansible sense (like the `setup`
+# task); the tasks in this file don't actually set up or mutate
+# anything.
 
 - name: Ansible pre-configuration
   set_fact:
@@ -8,7 +12,7 @@
 - name: Gathering facts (delayed after Ansible pre-configuration)
   setup:
 
-- name: Examine WordPress install
+- name: Inspect WordPress installed files
   stat:
     path: "{{ item }}"
   with_items:
@@ -16,6 +20,16 @@
     - "{{ wp_path_wpadmin }}"
   register: _wp_stat
 
+- name: Inspect WordPress plug-ins
+  shell: wp --path="{{ wp_dir }}" plugin list --format=json
+  register: _wp_plugin_list_json
+  changed_when: false
+  failed_when: false
+
 - set_fact:
     wp_is_installed: "{{ _wp_stat.results[0].stat.exists }}"
     wp_is_symlinked: "{{ _wp_stat.results[1].stat.islnk }}"
+    wp_plugin_list: >-
+      {{ (_wp_plugin_list_json.stdout if _wp_plugin_list_json.rc == 0
+                                      else '[]')
+         | from_json }}

--- a/ansible/roles/wordpress-instance/tasks/setup.yml
+++ b/ansible/roles/wordpress-instance/tasks/setup.yml
@@ -33,3 +33,10 @@
       {{ (_wp_plugin_list_json.stdout if _wp_plugin_list_json.rc == 0
                                       else '[]')
          | from_json }}
+
+- tags: ["never", "_debug_setup"]
+  debug:
+    msg:
+      - "{{ wp_is_installed }}"
+      - "{{ wp_is_symlinked }}"
+      - "{{ wp_plugin_list }}"

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -34,3 +34,8 @@ wp_base_url: "https://{{ wp_hostname }}/{{ wp_path }}"
 
 wp_themes_dir:  "{{ wp_dir }}/wp-content/themes"
 wp_plugins_dir: "{{ wp_dir }}/wp-content/plugins"
+
+# Shortcuts to facts collected by ../tasks/facts.yml
+wp_is_installed: "{{ ansible_facts.ansible_local.wp_is_installed }}"
+wp_is_symlinked: "{{ ansible_facts.ansible_local.wp_is_symlinked }}"
+wp_plugin_list: "{{ ansible_facts.ansible_local.wp_plugin_list }}"

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -67,7 +67,9 @@ set -e
 case "$mode" in
     ansible-playbook)
         ansible-galaxy install -i -r requirements.yml >/dev/null 2>&1
-        ansible-playbook $playbook_flags $inventories "$@" playbooks/wordpress-main.yml
+        ansible-playbook $playbook_flags $inventories "$@" \
+                         -e "wpsible_cwd=$OLDPWD" \
+                         playbooks/wordpress-main.yml
         ;;
     ansible)
         ansible $inventories $ansible_flags $common_flags "$@"


### PR DESCRIPTION
We can now say

```
./wp-ops/ansible/wpsible --prod -t facts,reportcsv
```
and get a report of all active plug-ins and their versions in `report.csv`

The fact collection (`-t facts` part) uses Ansible facts “the right way”, and caches them by default (no need to tweak your `~/.ansible.cfg`). New facts defined this way include `wp_is_installed`, `wp_is_symlinked` and `wp_plugin_list`.

[Example of a report generated using this data set](https://docs.google.com/spreadsheets/d/1bw5q1rEnmuSe3YV3lCedjznKFhMkA07yEQCTtJYdVDE)