### PR TITLE
Put "epfl-infoscience" and the "2010" plug-ins into the Docker images

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -110,9 +110,4 @@ RUN cp /wp/wp-content/plugins/index.php /wp/wp-content/mu-plugins/index.php
 RUN cd /wp/wp-content/plugins;                                           \
     /tmp/install-plugins-and-themes.py wordpress-importer wordpress.org/plugins
 
-# epfl-infoscience is pretty popular these days:
-RUN set -e -x;                                                           \
-    /tmp/install-plugins-and-themes.py epfl-infoscience                  \
-      https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-infoscience
-
 RUN rm -rf /tmp/install-plugins*

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -110,4 +110,9 @@ RUN cp /wp/wp-content/plugins/index.php /wp/wp-content/mu-plugins/index.php
 RUN cd /wp/wp-content/plugins;                                           \
     /tmp/install-plugins-and-themes.py wordpress-importer wordpress.org/plugins
 
+# epfl-infoscience is pretty popular these days:
+RUN set -e -x;                                                           \
+    /tmp/install-plugins-and-themes.py epfl-infoscience                  \
+      https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-infoscience
+
 RUN rm -rf /tmp/install-plugins*

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -395,8 +395,7 @@ class Jahia2wp2010(Jahia2wp2018):
         name = p.name
         if name in self.__PLUGINS_FAVORED_IN_RELEASE2018:
             return True
-        if not (name.startswith("EPFL") or
-                name.startswith("epfl")):
+        if not name.lower().startswith("epfl"):
             return True
         return False
 


### PR DESCRIPTION
Analysis of the ground truth in production reveals that

- this plugin is the single most used plugin that is currently *not*
  part of the image;

- it is extremely well curated, as all version numbers for this plugin
  are the same in production.