### PR TITLE
Mu-plugins improvements (reporting, symlinking discipline)

### DIFF
--- a/ansible/roles/wordpress-instance/defaults/main/report-vars.yml
+++ b/ansible/roles/wordpress-instance/defaults/main/report-vars.yml
@@ -1,3 +1,4 @@
 # Where to output the report made by `wpsible -t reportcsv`
 wpsible_cwd: "."
-report_csv_out: "{{ wpsible_cwd }}/report.csv"
+plugin_report_csv_out: "{{ wpsible_cwd }}/plugin-report.csv"
+muplugin_report_csv_out: "{{ wpsible_cwd }}/muplugin-report.csv"

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -88,5 +88,17 @@
   run_once: true
   local_action:
     module: copy
-    dest: "{{ report_csv_out }}"
+    dest: '{{ plugin_report_csv_out }}'
     content: '{{ hostvars | wp_plugin_versions_csv_report }}'
+
+# We could do a with_items but then we would get the entire content
+# dumped into the terminal as part of the "items" structure. Oh well
+- name: CSV must-use plug-in versions report
+  tags:
+    - never
+    - reportcsv
+  run_once: true
+  local_action:
+    module: copy
+    dest: '{{ muplugin_report_csv_out }}'
+    content: '{{ hostvars | wp_muplugin_versions_csv_report }}'

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -32,6 +32,8 @@
               *) exit $?                 ;;
           esac
       fi
+
+      rm -f "{{ wp_dir }}"/wp-content/mu-plugins/EPFL_enable_updates_automatic.php
   register: _symlink_script
   changed_when: '"SYMLINKS_CHANGED" in _symlink_script.stdout'
 

--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -48,6 +48,7 @@ symlinks_themes:
 _symlinks_muplugins_always:
   - EPFL_custom_editor_menu.php
   - EPFL_disable_comments.php
+  - EPFL_disable_updates_automatic.php
   - EPFL_google_analytics_hook.php
   - EPFL_jahia_redirect.php
   - EPFL_quota_loader.php
@@ -57,8 +58,7 @@ _symlinks_muplugins_always:
   - epfl-stats
 
 _symlinks_muplugins_managed:
-     - EPFL_enable_updates_automatic.php
-     - EPFL_installs_locked.php
+  - EPFL_installs_locked.php
 
 _symlinks_muplugins_yaml: |
   {{ _symlinks_muplugins_always | to_nice_yaml }}

--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -68,7 +68,9 @@ _symlinks_muplugins_yaml: |
 
 symlinks_muplugins: "{{ _symlinks_muplugins_yaml | from_yaml }}"
 
-symlinks_all_paths: "{{ symlinks_paths_wp                               \
-    + ('wp-content/plugins/%s'    | map_format(symlinks_plugins))       \
-    + ('wp-content/mu-plugins/%s' | map_format(symlinks_muplugins))     \
-    + ('wp-content/themes/%s'     | map_format(symlinks_themes))        }}"
+symlinks_all_paths: >
+  {{ symlinks_paths_wp
+    + ('wp-content/plugins/%s'    | map_format(symlinks_plugins))
+    + ('wp-content/mu-plugins/%s' | map_format(symlinks_muplugins))
+    + ('wp-content/themes/%s'     | map_format(symlinks_themes))
+  }}

--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -49,7 +49,6 @@ _symlinks_muplugins_always:
   - EPFL_custom_editor_menu.php
   - EPFL_disable_comments.php
   - EPFL_disable_updates_automatic.php
-  - EPFL_google_analytics_hook.php
   - EPFL_jahia_redirect.php
   - EPFL_quota_loader.php
   - EPFL_stats_loader.php
@@ -60,11 +59,24 @@ _symlinks_muplugins_always:
 _symlinks_muplugins_managed:
   - EPFL_installs_locked.php
 
+_symlinks_muplugins_by_group:
+  prod-inside:
+    - EPFL_google_analytics_hook.php
+  prod-labs:
+    - EPFL_google_analytics_hook.php
+  prod-www:
+    - EPFL_google_analytics_hook.php
+
 _symlinks_muplugins_yaml: |
   {{ _symlinks_muplugins_always | to_nice_yaml }}
   {% if wp_is_managed %}{#    From category-vars.yml  #}
   {{ _symlinks_muplugins_managed | to_nice_yaml }}
   {% endif %}
+  {% for group, moar_muplugins in _symlinks_muplugins_by_group %}
+  {% if group_names | intersect(["prod-inside"]) %}
+  {{ moar_muplugins | to_nice_yaml }}
+  {% endif %}
+  {% endfor %}
 
 symlinks_muplugins: "{{ _symlinks_muplugins_yaml | from_yaml }}"
 


### PR DESCRIPTION
- Produce a mu-plugin CSV report along with the plugin CSV report
- When a site is symlinked, be sure to get rid of its `mu-plugins/EPFL_enable_updates_automatic.php`
- Upon reviewing the data, we found that `EPFL_google_analytics_hook.php` is used exclusively in groups `prod-inside`, `prod-www` and `prod-labs` (in particular, not in `prod-subdomains`). Enforce that at `wpsible -t symlink` time