### PR TITLE
Misc. fixes and improvements from the aftermath of OUT0001470

### DIFF
--- a/ansible/playbooks/wordpress-main.yml
+++ b/ansible/playbooks/wordpress-main.yml
@@ -19,14 +19,6 @@
 - name: WordPress instances
   hosts: all-wordpresses
   gather_facts: no   # But see ../roles/wordpress-instance/tasks/facts.yml
-
-  # Set execution strategy to "free" (full parallelism) under -t
-  # symlink / -t unsymlink to minimize downtime; and to "linear" (the
-  # default value, slower but easier to reason about) otherwise
-  # https://docs.ansible.com/ansible/latest/user_guide/playbooks_strategies.html
-  strategy: >-
-    {{ "free" if ["symlink", "unsymlink"] | intersect(ansible_run_tags)
-       else "linear" }}
   roles:
     - role: ../roles/wordpress-instance
 

--- a/ansible/roles/wordpress-instance/tasks/configure.yml
+++ b/ansible/roles/wordpress-instance/tasks/configure.yml
@@ -5,7 +5,7 @@
 
 - assert:
     that:
-      - wp_can.configure
+      - wp_can.configure or ansible_check_mode
 
 - name: WP_CONTENT_DIR line in wp-config.php
   lineinfile:
@@ -23,4 +23,6 @@
 
 - name: Unset ping_sites
   command: "{{ wp_cli_command }} option set ping_sites ''"
-  when: "_wp_config_ping_sites.stdout != ''"
+  when: >
+    _wp_config_ping_sites is not skipped
+    and (_wp_config_ping_sites.stdout != '')

--- a/ansible/roles/wordpress-instance/tasks/configure.yml
+++ b/ansible/roles/wordpress-instance/tasks/configure.yml
@@ -7,11 +7,6 @@
     that:
       - wp_can.configure
 
-- name: Set up index.php
-  copy:
-    content: "{{ lookup('template', 'wordpress-index.php') }}"
-    dest: "{{ wp_dir }}/index.php"
-
 - name: WP_CONTENT_DIR line in wp-config.php
   lineinfile:
     state: "{{ 'present' if wp_is_symlinked else 'absent' }}"

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -17,27 +17,35 @@
 - include_vars: symlink-vars.yml
   tags: always
 
-- name: "Enter maintenance mode"
-  tags:
-    - symlink
-    - unsymlink
-  when: not ansible_check_mode
-  shell:
-    cmd: |
-      {{ lookup("template", "maintenance-lib.sh") }}
+- name: "Set wp_is_symlinked"
+  tags: always
+  set_fact:
+    wp_is_symlinked: '{{ "symlink" in ansible_run_tags }}'
 
-      set -e -x
+# WP_CONTENT_DIR can be set in wp-config.php prior to symlinking
+# without ill effects:
+- name: "Reconfigure wp-config.php before symlinking"
+  tags: symlink
+  include_tasks:
+    file: configure.yml
+    apply:
+      tags: ["symlink"]
 
-      enter_maintenance_mode
-
-- name: "Make symlinks"
+- name: "Symlink"
   tags: symlink
   check_mode: no   # Does The Right Thing under ansible-playbook --check
   shell:
     cmd: |
       {{ lookup("template", "symlinks-lib.sh") }}
+      {{ lookup("template", "maintenance-lib.sh") }}
 
       set -e -x
+      cd {{ wp_dir }}
+
+      {% if not ansible_check_mode %}
+      enter_maintenance_mode
+      trap leave_maintenance_mode EXIT HUP INT QUIT
+      {% endif %}
 
       if make_symlinks_to_wp {{ symlinks_all_paths | join(" ") }}; then :; else
           case "$?" in
@@ -46,65 +54,21 @@
           esac
       fi
 
-      rm -f "{{ wp_dir }}"/wp-content/mu-plugins/EPFL_enable_updates_automatic.php
-  register: _symlink_script
-  changed_when: '"SYMLINKS_CHANGED" in _symlink_script.stdout'
-
-- name: "Set wp_is_symlinked"
-  tags: symlink
-  set_fact:
-    wp_is_symlinked: true
-
-# Minimize downtime:
-- name: "Reconfigure"
-  tags: symlink
-  include_tasks:
-    file: configure.yml
-    apply:
-      tags: ["symlink"]
-
-- name: "Leave maintenance mode"
-  tags:
-    - symlink
-    - unsymlink
-  when: not ansible_check_mode
-  shell:
-    cmd: |
-      {{ lookup("template", "maintenance-lib.sh") }}
-
-      set -e -x
-
-      leave_maintenance_mode
-
-- name: "Clean up top-level files on symlinked site"
-  tags: symlink
-  check_mode: no
-  shell:
-    cmd: |
-      # Trim all files at top level, except for a whitelist
-      cd "{{ wp_dir }}"
-      files_trimmed=
-      for top_level_file in *; do
-          case "$top_level_file" in
-              .ht*) continue ;;
-              wp-config.php|index.php) continue ;;
-              {{ symlinks_all_paths | join('|') }}) continue ;;
+      if ensure_file_contains index.php <<INDEX_PHP
+      {{ lookup('template', 'wordpress-index.php') }}
+      INDEX_PHP
+      then
+          :
+      else
+          case "$?" in
+              1) echo INDEX_PHP_CHANGED ;;
+              *) exit $?                ;;
           esac
-          if [ -d "$top_level_file" ]; then continue; fi
-
-          if [ -z "$files_trimmed" ]; then
-              echo FILES_TRIMMED
-              files_trimmed=1
-          fi
-      {% if ansible_check_mode %}
-          echo >&2 "$top_level_file needs trimming"
-      {% else %}
-          rm -f "$top_level_file"
-      {% endif %}
-      done
-      
-  register: _symlink_cleanup_script
-  changed_when: '"FILES_TRIMMED" in _symlink_cleanup_script.stdout'
+      fi
+  register: _symlink_script
+  changed_when: >
+    "SYMLINKS_CHANGED" in _symlink_script.stdout or
+    "INDEX_PHP_CHANGED" in _symlink_script.stdout
 
 - name: "Unsymlink (copy from /wp)"
   tags: unsymlink
@@ -112,14 +76,37 @@
   check_mode: no
   shell:
     cmd: |
+      {{ lookup("template", "symlinks-lib.sh") }}
+      {{ lookup("template", "maintenance-lib.sh") }}
+
       set -e -x
       cd {{ wp_dir }}
+
+      if ensure_file_contains index.php <<INDEX_PHP
+      {{ lookup('template', 'wordpress-index.php') }}
+      INDEX_PHP
+      then
+          :
+      else
+          case "$?" in
+              1) echo INDEX_PHP_CHANGED ;;
+              *) exit $?                ;;
+          esac
+      fi
+
+      {% if not ansible_check_mode %}
+      enter_maintenance_mode
+      trap leave_maintenance_mode EXIT HUP INT QUIT
+      {% endif %}
+
       if [ "" = "$(find . -name uploads -prune -false -o -type l)" ]; then
         echo NO_SYMLINKS
         exit 0
       fi
 
-      [ "$ansible_check_mode" = "True" ] && exit 0
+      {% if ansible_check_mode %}
+      exit 0
+      {% endif %}
 
       for subdir in wp-content/themes wp-content/plugins \
                     wp-content/mu-plugins; do
@@ -131,15 +118,43 @@
 
       (cd /wp; tar clf - .) | tar xpvf -
   register: _unsymlink_script
-  changed_when: '"NO_SYMLINKS" not in _unsymlink_script.stdout'
+  changed_when: >
+    "INDEX_PHP_CHANGED" in _unsymlink_script.stdout or
+    "NO_SYMLINKS" not in _unsymlink_script.stdout
 
-- name: "Reset wp_is_symlinked"
-  tags: unsymlink
-  set_fact:
-    wp_is_symlinked: false
+- name: "Clean up stale files on symlinked site"
+  tags: symlink
+  check_mode: no
+  shell:
+    cmd: |
+      # Trim all files at top level (except for a whitelist), and
+      # the auto-update muplugin
+      cd "{{ wp_dir }}"
+      files_trimmed=
+      for path in * \
+          wp-content/mu-plugins/EPFL_enable_updates_automatic.php
+      do
+          case "$path" in
+              .ht*) continue ;;
+              wp-config.php|index.php) continue ;;
+              {{ symlinks_all_paths | join('|') }}) continue ;;
+          esac
+          if [ -d "$path" ]; then continue; fi
 
-# Minimize downtime:
-- name: "Reconfigure"
+          if [ -z "$files_trimmed" ]; then
+              echo FILES_TRIMMED
+              files_trimmed=1
+          fi
+      {% if ansible_check_mode %}
+          echo >&2 "$path needs trimming"
+      {% else %}
+          rm -f "$path"
+      {% endif %}
+      done
+  register: _symlink_cleanup_script
+  changed_when: '"FILES_TRIMMED" in _symlink_cleanup_script.stdout'
+
+- name: "Reconfigure wp-config.php after unsymlinking"
   tags: unsymlink
   include_tasks:
     file: configure.yml

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -129,7 +129,10 @@
     cmd: |
       # Trim all files at top level (except for a whitelist), and
       # the auto-update muplugin
+
+      set -e -x
       cd "{{ wp_dir }}"
+
       files_trimmed=
       for path in * \
           wp-content/mu-plugins/EPFL_enable_updates_automatic.php
@@ -139,6 +142,7 @@
               wp-config.php|index.php) continue ;;
               {{ symlinks_all_paths | join('|') }}) continue ;;
           esac
+          if [ ! -e "$path" ]; then continue; fi
           if [ -d "$path" ]; then continue; fi
 
           if [ -z "$files_trimmed" ]; then

--- a/ansible/roles/wordpress-instance/templates/maintenance-lib.sh
+++ b/ansible/roles/wordpress-instance/templates/maintenance-lib.sh
@@ -14,7 +14,7 @@ HTACCESS_MAINTENANCE
 }
 
 leave_maintenance_mode() {
-    local htaccess htaccesstmp
+    local htaccess
 
     htaccess="{{ wp_dir }}"/.htaccess
     mv "$htaccess.bak" "$htaccess"

--- a/ansible/roles/wordpress-instance/templates/maintenance-lib.sh
+++ b/ansible/roles/wordpress-instance/templates/maintenance-lib.sh
@@ -2,17 +2,20 @@
 
 enter_maintenance_mode() {
     local htaccess htaccesstmp
+
     htaccess="{{ wp_dir }}"/.htaccess
+    cp --backup=numbered "$htaccess" "$htaccess.bak"
+
     htaccesstmp="$htaccess"_tmp_$$
-    (echo "RewriteRule .* /global-error/303-to-sorryserver.php [L]";
-     grep -v /303-to-sorryserver.php "$htaccess") > "$htaccesstmp"
+    cat > "$htaccesstmp" <<HTACCESS_MAINTENANCE
+RewriteRule .* /global-error/303-to-sorryserver.php [L]
+HTACCESS_MAINTENANCE
     mv "$htaccesstmp" "$htaccess"
 }
 
 leave_maintenance_mode() {
     local htaccess htaccesstmp
+
     htaccess="{{ wp_dir }}"/.htaccess
-    htaccesstmp="$htaccess"_tmp_$$
-    grep -v /303-to-sorryserver.php "$htaccess" > "$htaccesstmp"
-    mv "$htaccesstmp" "$htaccess"
+    mv "$htaccess.bak" "$htaccess"
 }

--- a/ansible/roles/wordpress-instance/templates/symlinks-lib.sh
+++ b/ansible/roles/wordpress-instance/templates/symlinks-lib.sh
@@ -30,3 +30,22 @@ make_symlinks_to_wp() {
     done
     return $retval
 }
+
+ensure_file_contains () {
+    local oldfilename newfilename
+    oldfilename="$1"
+    newfilename="$1.NEW.$$"
+    cat > "$newfilename"
+    if diff "$oldfilename" "$newfilename" >&2; then
+        rm "$newfilename"
+        return 0
+    else
+{% if ansible_check_mode %}
+      # We have enough chatter from "diff", above
+      rm "$newfilename"
+{% else %}
+      mv "$newfilename" "$oldfilename"
+{% endif %}
+      return 1
+    fi
+}

--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -1,5 +1,5 @@
 ;; EPFL-specific tunings for PHP
 
-realpath_cache_size = 40M
-realpath_cache_ttl = 1800
-
+;; In a symlinked serving environment, the realpath cache is a pure
+;; liability - disable it and rely on the NFS attribute cache instead.
+realpath_cache_size = 0M


### PR DESCRIPTION
- Back up / restore .htaccess instead of editing it (suggested by @LuluTchab)
- Do the symlink dance in one shell script
- Disable realpath_cache, lest “unsymlink” basically have no effect
