### PR TITLE
Plugin and theme state in Ansible

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -1,0 +1,6 @@
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        return super(ActionModule, self).run(tmp, task_vars)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -1,0 +1,6 @@
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        return super(ActionModule, self).run(tmp, task_vars)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -1,0 +1,6 @@
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        return super(ActionModule, self).run(tmp, task_vars)

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -6,10 +6,7 @@
 #              ../vars/*.yml)
 
 - include_vars: wp-destructive.yml   # For wp_can
-  tags:
-    - symlink
-    - unsymlink
-    - config
+  tags: always
 
 - name: WordPress facts
   import_tasks: facts.yml

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -65,6 +65,24 @@
     apply:
       tags: ["config"]
 
+- name: Set up plugins
+  when: wp_can.configure
+  tags:
+    - plugins
+  include_tasks:
+    file: "plugins.yml"
+    apply:
+      tags: ["plugins"]
+
+- name: Set up themes
+  when: wp_can.configure
+  tags:
+    - themes
+  include_tasks:
+    file: "themes.yml"
+    apply:
+      tags: ["themes"]
+
 ################################
 # Special-purpose tasks
 ################################

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -1,0 +1,327 @@
+- include_vars: "{{ item }}"
+  with_items:
+    - plugin-vars.yml
+    - accred-vars.yml
+
+- name: Delete plugins bundled with WordPress
+  wordpress_plugin:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - akismet
+    - hello
+
+- name: simple-sitemap plugin
+  wordpress_plugin:
+    name: simple-sitemap
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: tinymce-advanced plugin
+  wordpress_plugin:
+    name: tinymce-advanced
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: polylang plugin
+  wordpress_plugin:
+    name: polylang
+    state: symlinked
+    from: wordpress.org/plugins
+
+# TODO: recapture intent of jahia2wp's
+# src/wordpress/plugins/custom/polylang.py
+# (perhaps not in this file)
+
+- name: mainwp-child plugin
+  wordpress_plugin:
+    name: mainwp-child
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: mainwp_child_uniqueId option
+  wordpress_option:
+    name: mainwp_child_uniqueId
+    value: "{{ plugin_mainwp_child_uniqueid }}"
+    # TODO: this value has "autoload: no" in
+    # jahia2wp/data/plugins/generic/mainwp-child/config-plugin.yml ;
+    # not sure what it means (if anything)
+
+- name: tequila plugin
+  wordpress_plugin:
+    name: tequila
+    state: symlinked
+    from: https://github.com/epfl-sti/wordpress.plugin.tequila/archive/vpsi.zip
+
+- name: Replace WP login screen with redirect-to-Tequila flow
+  wordpress_option:
+    name: plugin:epfl_tequila:has_dual_auth
+    value: 0
+
+- name: Whitelist of IPs for Tequila fetchAttributes request
+  wordpress_option:
+    name: plugin:epfl:tequila_allowed_request_hosts
+    value: "{{ wp_ops_rpcclient_ipv4_range }}"
+
+- name: accred plugin
+  wordpress_plugin:
+    name: accred
+    state: symlinked
+    from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
+
+- name: accred administrator group
+  wordpress_option:
+    name: plugin:epfl_accred:administrator_group
+    value: "{{ wp_administrator_group }}"
+
+- name: accred unit name
+  wordpress_option:
+    name: plugin:epfl_accred:unit
+    value: "{{ wp_unit_name }}"
+
+- name: accred unit ID
+  wordpress_option:
+    name: plugin:epfl_accred:unit_id
+    value: "{{ wp_unit_id }}"
+
+- name: cache-control plugin
+  wordpress_plugin:
+    name: cache-control
+    state: symlinked
+    from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
+
+- name: cache-control options
+  wordpress_option:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - name: cache_control_front_page_max_age
+      value: "{{ plugin_cache_control_front_page_max_age }}"
+    - name: cache_control_pages_max_age
+      value: "{{ plugin_cache_control_pages_max_age }}"
+
+- name: varnish-http-purge plugin
+  wordpress_plugin:
+    name: varnish-http-purge
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: EPFL-settings plugin
+  wordpress_plugin:
+    name: EPFL-settings
+    state: symlinked
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-settings
+
+- name: custom_breadcrumb option for EPFL-settings plugin
+  wordpress_option:
+    name: epfl:custom_breadcrumb
+    value: ""
+
+- name: EPFL-Content-Filter plugin
+  wordpress_plugin:
+    name: EPFL-Content-Filter
+    state: '{{ "symlinked" if plugins_locked else "absent" }}'
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-Content-Filter
+
+- name: svg-support plugin
+  wordpress_plugin:
+    name: svg-support
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: Dismiss svg-support popup
+  wordpress_option:
+    name: bodhi_svgs_admin_notice_dismissed
+    value: 1
+
+- name: feedzy-rss-feeds plugin
+  wordpress_plugin:
+    name: feedzy-rss-feeds
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: remote-content-shortcode plugin
+  wordpress_plugin:
+    name: remote-content-shortcode
+    state: symlinked
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/remote-content-shortcode
+
+- name: shortcode-ui plugin
+  wordpress_plugin:
+    name: shortcode-ui
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: shortcode-ui-richtext plugin
+  wordpress_plugin:
+    name: shortcode-ui-richtext
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: epfl plugin
+  wordpress_plugin:
+    name: epfl
+    state: >
+      {{ "absent" if plugins_use_wp2010_plugins else "symlinked" }}
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
+
+- name: wp-media-folder plugin
+  wordpress_plugin:
+    name: wp-media-folder
+    state: symlinked
+    from: https://wp-manager.epfl.ch/resources/plugin-zip/wp-media-folder.zip
+
+- name: wp-media-folder options
+  wordpress_option: "{{ item }}"
+  with_items: "{{ plugin_wpmf_options }}"
+
+- name: pdfjs-viewer-shortcode plugin
+  wordpress_plugin:
+    name: pdfjs-viewer-shortcode
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: very-simple-meta-description plugin
+  wordpress_plugin:
+    name: very-simple-meta-description
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: epfl-404 plugin
+  wordpress_plugin:
+    name: epfl-404
+    state: symlinked
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-404
+
+- name: ewww-image-optimizer plugin
+  wordpress_plugin:
+    name: ewww-image-optimizer
+    state: symlinked
+    from: wordpress.org/plugins
+
+- name: ewww-image-optimizer configuration
+  wordpress_option: "{{ item }}"
+  with_items: "{{ plugin_ewww_image_optimizer_options }}"
+
+
+##################### 2010-only plugins ###########################
+
+- name: EPFL-Share plugin
+  wordpress_plugin:
+    name: EPFL-Share
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/EPFL-Share
+
+- name: shortcodes-ultimate plugin
+  wordpress_plugin:
+    name: shortcodes-ultimate
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: wordpress.org/plugins
+
+- name: enlighter plugin
+  wordpress_plugin:
+    name: enlighter
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: wordpress.org/plugins
+
+- name: epfl-scheduler plugin
+  wordpress_plugin:
+    name: epfl-scheduler
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-scheduler
+
+- name: epfl-news plugin
+  wordpress_plugin:
+    name: epfl-news
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-news
+
+- name: epfl-memento plugin
+  wordpress_plugin:
+    name: epfl-memento
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-memento
+
+- name: epfl-faq plugin
+  wordpress_plugin:
+    name: epfl-faq
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-faq
+
+- name: epfl-map plugin
+  wordpress_plugin:
+    name: epfl-map
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-map
+
+- name: epfl-buttons plugin
+  wordpress_plugin:
+    name: epfl-buttons
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-buttons
+
+- name: epfl-snippet plugin
+  wordpress_plugin:
+    name: epfl-snippet
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-snippet
+
+- name: epfl-toggle plugin
+  wordpress_plugin:
+    name: epfl-toggle
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-toggle
+
+- name: epfl-grid plugin
+  wordpress_plugin:
+    name: epfl-grid
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-grid
+
+- name: epfl-infoscience plugin
+  wordpress_plugin:
+    name: epfl-infoscience
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience
+
+- name: epfl-infoscience-search plugin
+  wordpress_plugin:
+    name: epfl-infoscience-search
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience-search
+
+- name: epfl-xml plugin
+  wordpress_plugin:
+    name: epfl-xml
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-xml
+
+- name: epfl-people plugin
+  wordpress_plugin:
+    name: epfl-people
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-people
+
+- name: epfl-twitter plugin
+  wordpress_plugin:
+    name: epfl-twitter
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-twitter
+
+- name: epfl-video plugin
+  wordpress_plugin:
+    name: epfl-video
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-video
+
+- name: epfl-tableau plugin
+  wordpress_plugin:
+    name: epfl-tableau
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-tableau
+
+- name: epfl-google-forms plugin
+  wordpress_plugin:
+    name: epfl-google-forms
+    state: "{{ plugins_symlinked_in_2010_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-google-forms

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -1,3 +1,11 @@
+## Plugin lineup and configuration
+##
+## ⚠ Until such time that we don't use the jahia2wp repository, the
+## configuration herein duplicates the one at
+## https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/plugins/generic/config-lot1.yml
+## (and ditto in the "release" branch as well).
+## Please be sure to propagate your changes there as well.
+
 - include_vars: wp-destructive.yml   # For wp_can
 - assert:
     that: wp_can.configure

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -1,3 +1,7 @@
+- include_vars: wp-destructive.yml   # For wp_can
+- assert:
+    that: wp_can.configure
+
 - include_vars: "{{ item }}"
   with_items:
     - plugin-vars.yml

--- a/ansible/roles/wordpress-instance/tasks/themes.yml
+++ b/ansible/roles/wordpress-instance/tasks/themes.yml
@@ -1,3 +1,7 @@
+- include_vars: wp-destructive.yml   # For wp_can
+- assert:
+    that: wp_can.configure
+
 - name: Delete themes bundled with WordPress
   wordpress_theme:
     name: "{{ item }}"

--- a/ansible/roles/wordpress-instance/tasks/themes.yml
+++ b/ansible/roles/wordpress-instance/tasks/themes.yml
@@ -2,11 +2,9 @@
 - assert:
     that: wp_can.configure
 
-- name: Delete themes bundled with WordPress
+- include_vars: theme-vars.yml
+
+- name: WordPress theme
   wordpress_theme:
-    name: "{{ item }}"
-    state: absent
-  with_items:
-    - twentyfifteen
-    - twentysixteen
-    - twentyseventeen
+    name: '{{ theme_name }}'
+    state: symlinked

--- a/ansible/roles/wordpress-instance/tasks/themes.yml
+++ b/ansible/roles/wordpress-instance/tasks/themes.yml
@@ -1,0 +1,8 @@
+- name: Delete themes bundled with WordPress
+  wordpress_theme:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - twentyfifteen
+    - twentysixteen
+    - twentyseventeen

--- a/ansible/roles/wordpress-instance/vars/accred-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/accred-vars.yml
@@ -1,0 +1,4 @@
+# Variables related to EPFL accred system and access control
+wp_administrator_group: WP_SuperAdmin
+wp_unit_name: "TODO obtain from wp-veritas"
+wp_unit_id: 1234   # also TODO

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -39,3 +39,7 @@ wp_plugins_dir: "{{ wp_dir }}/wp-content/plugins"
 wp_is_installed: "{{ ansible_facts.ansible_local.wp_is_installed }}"
 wp_is_symlinked: "{{ ansible_facts.ansible_local.wp_is_symlinked }}"
 wp_plugin_list: "{{ ansible_facts.ansible_local.wp_plugin_list }}"
+
+# Range of IPv4 addresses that we could be making RPCs from (in
+# particular, to Tequila)
+wp_ops_rpcclient_ipv4_range: 10.180.21.0/24

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -11,7 +11,7 @@
 # roles/wordpress-instance/vars/main.yml is implicitly imported
 # whenever the "wordpress" role is in play in a playbook, the other
 # files in this directory need to be imported explicitly using the
-# import_vars task.
+# include_vars task.
 
 # The top-level directory of this WordPress instance
 wp_dir: "/srv/{{ wp_env }}/{{ wp_hostname }}/htdocs/{{ wp_path }}"

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -1,0 +1,145 @@
+# Plugin variables go here
+
+# TODO: These two should be computed from wp-veritas state
+plugins_locked: true
+plugins_use_wp2010_plugins: false
+plugins_symlinked_in_2010_only: '{{ "symlinked" if plugins_use_wp2010_plugins else "absent" }}'
+
+plugin_mainwp_child_uniqueid: "WinterIsComing"
+
+plugin_cache_control_front_page_max_age: 300
+plugin_cache_control_pages_max_age: 300
+
+plugin_wpmf_options:
+  - name: wpmf_use_taxonomy
+    value: '1'
+  - name: wpmf_version
+    value: 4.7.0
+  - name: wpmf_gallery_image_size_value
+    value: '["thumbnail","medium","large","full"]'
+  - name: wpmf_padding_masonry
+    value: '5'
+  - name: wpmf_padding_portfolio
+    value: '10'
+  - name: wpmf_usegellery
+    value: '0'
+  - name: wpmf_useorder
+    value: '1'
+  - name: wpmf_create_folder
+    value: role
+  - name: wpmf_option_override
+    value: '1'
+  - name: wpmf_option_duplicate
+    value: '0'
+  - name: wpmf_active_media
+    value: '0'
+  - name: wpmf_folder_option2
+    value: '1'
+  - name: wpmf_option_searchall
+    value: '1'
+  - name: wpmf_usegellery_lightbox
+    value: '0'
+  - name: wpmf_media_rename
+    value: '0'
+  - name: wpmf_patern_rename
+    value: '{sitename} - {foldername} - #'
+  - name: wpmf_rename_number
+    value: '0'
+  - name: wpmf_option_media_remove
+    value: '0'
+  - name: wpmf_default_dimension
+    value: '["400x300","640x480","800x600","1024x768","1600x1200"]'
+  - name: wpmf_selected_dimension
+    value: '["400x300","640x480","800x600","1024x768","1600x1200"]'
+  - name: wpmf_weight_default
+    value: '[["0-61440","kB"],["61440-122880","kB"],["122880-184320","kB"],["184320-245760","kB"],["245760-307200","kB"]]'
+  - name: wpmf_weight_selected
+    value: '[["0-61440","kB"],["61440-122880","kB"],["122880-184320","kB"],["184320-245760","kB"],["245760-307200","kB"]]'
+  - name: wpmf_color_singlefile
+    value: '{"bgdownloadlink":"#444444","hvdownloadlink":"#888888","fontdownloadlink":"#ffffff","hoverfontcolor":"#ffffff"}'
+  - name: wpmf_option_singlefile
+    value: '0'
+  - name: wpmf_option_sync_media
+    value: '0'
+  - name: wpmf_option_sync_media_external
+    value: '0'
+  - name: wpmf_list_sync_media
+    value: a:0:{}
+  - name: wpmf_time_sync
+    value: '60'
+  - name: wpmf_lastRun_sync
+    value: '1540467937'
+  - name: wpmf_slider_animation
+    value: slide
+  - name: wpmf_option_mediafolder
+    value: '0'
+  - name: wpmf_option_countfiles
+    value: '1'
+  - name: wpmf_option_lightboximage
+    value: '0'
+  - name: wpmf_option_hoverimg
+    value: '1'
+  - name: wpmf_options_format_title
+    value: a:15:{s:6:"hyphen";s:1:"1";s:6:"period";s:1:"0";s:4:"plus";s:1:"0";s:9:"ampersand";s:1:"0";s:15:"square_brackets";s:1:"0";s:14:"curly_brackets";s:1:"0";s:10:"underscore";s:1:"1";s:5:"tilde";s:1:"0";s:4:"hash";s:1:"0";s:6:"number";s:1:"0";s:14:"round_brackets";s:1:"0";s:3:"alt";s:1:"0";s:11:"description";s:1:"0";s:7:"caption";s:1:"0";s:6:"capita";s:7:"cap_all";}
+  - name: wpmf_image_watermark_apply
+    value: a:5:{s:8:"all_size";s:1:"1";s:9:"thumbnail";s:1:"0";s:6:"medium";s:1:"0";s:5:"large";s:1:"0";s:4:"full";s:1:"0";}
+  - name: wpmf_option_image_watermark
+    value: '0'
+  - name: wpmf_watermark_position
+    value: top_left
+  - name: wpmf_watermark_image
+    value: ''
+  - name: wpmf_watermark_image_id
+    value: '0'
+  - name: wpmf_gallery_settings
+    value: >
+      a:1:{s:5:"theme";a:7:{s:13:"default_theme";a:6:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:15:"portfolio_theme";a:6:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:13:"masonry_theme";a:6:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:12:"slider_theme";a:9:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";s:9:"animation";s:5:"slide";s:8:"duration";i:4000;s:14:"auto_animation";i:1;}s:15:"flowslide_theme";a:7:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";s:12:"show_buttons";i:1;}s:17:"square_grid_theme";a:6:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:14:"material_theme";a:6:{s:7:"columns";i:3;s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}}}
+  - name: external_updates-wp-media-folder
+    value: |
+      O:8:"stdClass":3:{s:9:"lastCheck";i:1540467937;s:14:"checkedVersion";s:5:"4.7.0";s:6:"update";O:8:"stdClass":7:{s:2:"id";i:0;s:4:"slug";s:15:"wp-media-folder";s:7:"version";s:5:"4.7.2";s:8:"homepage";s:61:"https://www.joomunited.com/wordpress-products/wp-media-folder";s:12:"download_url";s:120:"https://www.joomunited.com/index.php?option=com_juupdater&task=download.download&extension=wp-media-folder&version=4.7.2";s:14:"upgrade_notice";s:29:"Upgrade
+      to the latest version";s:8:"filename";s:35:"wp-media-folder/wp-media-folder.php";}}
+  - name: wpmf_settings
+    value: >
+      a:9:{s:17:"hide_remote_video";s:1:"0";s:16:"gallery_settings";a:1:{s:5:"theme";a:4:{s:13:"default_theme";a:6:{s:7:"columns";s:1:"3";s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:15:"portfolio_theme";a:6:{s:7:"columns";s:1:"3";s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:13:"masonry_theme";a:6:{s:7:"columns";s:1:"3";s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:5:"order";s:3:"ASC";}s:12:"slider_theme";a:9:{s:7:"columns";s:1:"3";s:4:"size";s:6:"medium";s:10:"targetsize";s:5:"large";s:4:"link";s:4:"file";s:7:"orderby";s:8:"post__in";s:9:"animation";s:5:"slide";s:8:"duration";s:4:"4000";s:5:"order";s:3:"ASC";s:14:"auto_animation";s:1:"1";}}}s:25:"watermark_exclude_folders";a:1:{i:0;s:1:"0";}s:13:"folder_design";s:15:"material_design";s:8:"load_gif";s:1:"1";s:9:"hide_tree";s:1:"1";s:16:"watermark_margin";a:4:{s:3:"top";s:1:"0";s:5:"right";s:1:"0";s:6:"bottom";s:1:"0";s:4:"left";s:1:"0";}s:23:"watermark_image_scaling";s:3:"100";s:17:"format_mediatitle";s:1:"1";}
+  - name: _wpmf_import_order_notice_flag
+    value: 'yes'
+  - name: can_compress_scripts
+    value: '0'
+
+plugin_ewww_image_optimizer_options:
+  - option_name: exactdn_all_the_things
+    option_value: ''
+  - option_name: exactdn_lossy
+    option_value: ''
+  - option_name: ewww_image_optimizer_tracking_notice
+    option_value: '1'
+  - option_name: ewww_image_optimizer_enable_help_notice
+    option_value: '1'
+  - option_name: ewww_image_optimizer_cloud_key
+    option_value: ''
+  - option_name: ewww_image_optimizer_jpg_quality
+    option_value: ''
+  - option_name: ewww_image_optimizer_include_media_paths
+    option_value: '1'
+  - option_name: ewww_image_optimizer_aux_paths
+    option_value: ''
+  - option_name: ewww_image_optimizer_exclude_paths
+    option_value: ''
+  - option_name: ewww_image_optimizer_allow_tracking
+    option_value: ''
+  - option_name: ewww_image_optimizer_maxmediawidth
+    option_value: '2048'
+  - option_name: ewww_image_optimizer_maxmediaheight
+    option_value: '2048'
+  - option_name: ewww_image_optimizer_resize_existing
+    option_value: '1'
+  - option_name: ewww_image_optimizer_disable_resizes
+    option_value: ''
+  - option_name: ewww_image_optimizer_disable_resizes_opt
+    option_value: ''
+  - option_name: ewww_image_optimizer_jpg_background
+    option_value: ''
+  - option_name: ewww_image_optimizer_webp_paths
+    option_value: ''
+  - option_name: ewww_image_optimizer_dismiss_media_notice
+    option_value: '1'

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -143,3 +143,5 @@ plugin_ewww_image_optimizer_options:
     option_value: ''
   - option_name: ewww_image_optimizer_dismiss_media_notice
     option_value: '1'
+  - option_name: ewww_image_optimizer_debug
+    option_value: false

--- a/ansible/roles/wordpress-instance/vars/theme-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/theme-vars.yml
@@ -1,0 +1,4 @@
+# Theme variables go here
+
+# TODO: This should be computed from wp-veritas state
+theme_name: "wp-theme-2018"

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -83,7 +83,8 @@ RUN wp --allow-root --path=/wp core download \
                       | select(match("'${WORDPRESS_VERSION_LINEAGE}'"))' \
             |sort -n -r |head -1)
 
-RUN rm -rf /wp/wp-content/plugins/akismet /wp/wp-content/plugins/hello.php
+RUN rm -rf /wp/wp-content/plugins/akismet /wp/wp-content/plugins/hello.php \
+    /wp/wp-content/themes/twenty*
 
 ADD wordpress-anywhere.patch /tmp/
 RUN set -e -x; cd /; git apply < /tmp/wordpress-anywhere.patch;          \

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -97,7 +97,7 @@ class GitHubCheckout:
     @classmethod
     def _parse(cls, url):
         matched_with_tree = re.match(
-            'https://github.com/([^/]*)/([^/]*)/tree/([^/]*)(?:$|/(.*))', url)
+            'https://github.com/([^/]*)/([^/]*)/tree/((?:(?:feature|bugfix)/)?[^/]+)(?:$|/(.*))', url)
         if matched_with_tree:
             return matched_with_tree
         else:

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -292,7 +292,7 @@ class WpOpsPlugins(_Singleton):
     """Models the plugins enumerated in the "wp-ops" Ansible configuration."""
 
     # TODO: unfork to master
-    _GIT_URL = 'https://github.com/epfl-idevelop/wp-ops/tree/feature/plugin-and-theme-state-in-ansible'
+    _GIT_URL = 'https://github.com/epfl-idevelop/wp-ops'
     PLUGINS_YML_PATH = 'ansible/roles/wordpress-instance/tasks/plugins.yml'
 
     def __init__(self):


### PR DESCRIPTION
This is the first step towards moving the ground truth about plugins, themes and configuration options from [jahia2wp](https://github.com/epfl-idevelop/jahia2wp) to wp-ops.

- Add infrastructure under `ansible/` to manage plugins, themes and WP options (stubbed out for now)
- Translate `config-lot1.yml` from both jahia2wp branches (`release` and `release2018`) into Ansible
- `install-plugins-and-themes.py` now parses the YAML out of said Ansible state, rather than the one in jahia2wp
- Put up temporary warning at the top of  `plugins.yml` that explains that that configuration now exists in duplicate
