### PR TITLE
Bugfix: Jenkins said "deployment already in progress"

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
+++ b/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
@@ -166,7 +166,7 @@ void watchBuild(buildSelector) {
 
   buildSelector.logs('-f')  // Waits for the build(s) to terminate
                             // (or mostly terminate - See below)
-  timeout(1) {
+  timeout(time: 1, units: 'MINUTES') {
     // Despite logs having run their course, experience shows that
     // some builds can still be in "Running" state Kubernetes-wise:
     buildSelector.withEach {
@@ -215,7 +215,7 @@ void awaitTriggeredBuildsStarted(buildSelector, expectedSize) {
 
   def triggeredBuilds = []
 
-  timeout(2) {
+  timeout(time: 2, units: 'MINUTES') {
     for (build in openshift.selector("build").objects()) {
       if (build.spec && build.spec.triggeredBy) {
         for (triggered in build.spec.triggeredBy) {

--- a/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
+++ b/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
@@ -99,12 +99,19 @@ spec:
             openshift.withProject() {
               def latestDeploymentVersion = openshift.selector('dc', 'httpd-int').object().status.latestVersion
               def rc = openshift.selector('rc', "httpd-int-${latestDeploymentVersion}")
-              rc.untilEach(1) {  // Wait until there is one result in the
-                                 // selector, *and then* each shall return
-                                 // true below:
+              Set mentioned = []
+              rc.untilEach(1) {  // Wait until there is (at least) one
+                                 // result in the selector, *and then*
+                                 // each shall return true below:
                 def rcMap = it.object()
-                return (rcMap.status.replicas.equals(
-                  rcMap.status.readyReplicas))
+                def name = rcMap.metadata.name
+                def expectedReplicas = rcMap.status.replicas
+                def actualReplicas = rcMap.status.readyReplicas
+                if (! mentioned.contains(name)) {
+                  echo "Waiting for rc/${name} to reach ${expectedReplicas} replicas (currently ${actualReplicas})"
+                  mentioned.add(name)
+                }
+                return (expectedReplicas.equals(actualReplicas))
               }  // rc.untilEach
             }  // openshift.withProject
           }  // openshift.withCluster

--- a/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
+++ b/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
@@ -97,9 +97,15 @@ spec:
         script {
           openshift.withCluster() {
             openshift.withProject() {
-              def rollout = openshift.selector('dc', 'httpd-int').rollout()
-              rollout.latest()
-              rollout.status()
+              def latestDeploymentVersion = openshift.selector('dc', 'httpd-int').object().status.latestVersion
+              def rc = openshift.selector('rc', "httpd-int-${latestDeploymentVersion}")
+              rc.untilEach(1) {  // Wait until there is one result in the
+                                 // selector, *and then* each shall return
+                                 // true below:
+                def rcMap = it.object()
+                return (rcMap.status.replicas.equals(
+                  rcMap.status.readyReplicas))
+              }  // rc.untilEach
             }  // openshift.withProject
           }  // openshift.withCluster
         }  // script


### PR DESCRIPTION
[We recently had a rash of red Jenkins builds](https://jenkins-wwp-test.epfl.ch/job/wwp-test/job/wwp-test-httpd-jenkins-dev/) caused by Jenkins attempting to deploy `dc/httpd-int`, whereas that DeploymentConfig automatically redeploys itself whenever we build a new `httpd` image in `wwp-test`.

- Watch the DeploymentConfig instead of causing it, based the sample code in https://github.com/openshift/jenkins-client-plugin#looking-to-verify-a-deployment-or-service-we-can-still-do-that 
- `echo` a brief explanation of what we are waiting for once per deployment
