### PR TITLE
Emergency fix - Content of /wp/wp-content/plugins/cache-control is bogus

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -100,7 +100,7 @@
   wordpress_plugin:
     name: cache-control
     state: symlinked
-    from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
+    from: wordpress.org/plugins
 
 - name: cache-control options
   wordpress_option:


### PR DESCRIPTION
Following a typo, the content of  /wp/wp-content/plugins/cache-control is bogus in the image (contains a copy of the epfl-accred plugin). Fix it
