### PR TITLE
Don't walk /srv/lvenries or /srv/jenkins

### DIFF
--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -78,7 +78,9 @@ sub collect_wordpress_installs_over_ssh {
             # local bash that will parse this open('-|'), and a second
             # time for the remote shell.
             qw<'\(' -type d
-               '\(' -name wp-\'*\' -o -name .git -o -name \'*\'packages -o -name 'jahia-data' '\)'
+               '\(' -name wp-\'*\' -o -name .git -o -name \'*\'packages
+                    -o -name 'jahia-data'
+                    -o -path /srv/lvenries -o -path /srv/jenkins '\)'
                '\)' -prune -false -o -name wp-config.php>))
     or die "Cannot ssh $ssh_mantra: $!";
 


### PR DESCRIPTION
This rids us of a spew of red errors (introduced in #69) every time we
run anything.