### PR TITLE
Manage mu-plugins in Ansible config

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -1,4 +1,4 @@
-## Plugin lineup and configuration
+## Plugin and mu-plugin lineup and configuration
 ##
 ## ⚠ Until such time that we don't use the jahia2wp repository, the
 ## configuration herein duplicates the one at
@@ -23,11 +23,75 @@
     - akismet
     - hello
 
-- name: simple-sitemap plugin
+##################### Must-use plugins ###########################
+
+- name: Custom editor menu (must-use plugin)
   wordpress_plugin:
-    name: simple-sitemap
-    state: symlinked
-    from: wordpress.org/plugins
+    name: EPFL_custom_editor_menu
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+
+- name: Disable comments (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_disable_comments
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
+
+- name: Disable automatic updates (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_disable_updates_automatic
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_updates_automatic.php
+
+- name: Google Analytics hook (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_google_analytics_hook
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_google_analytics_hook.php
+
+- name: Locked installs (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_installs_locked
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+
+- name: Jahia redirect tracker (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_jahia_redirect
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+
+- name: EPFL functions (must-use plugin)
+  wordpress_plugin:
+    name: epfl-functions
+    state:
+      - symlinked
+      - must-use
+    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-functions.php
+
+- name: Stats (must-use plugin)
+  wordpress_plugin:
+    name: EPFL_stats_loader
+    state:
+      - symlinked
+      - must-use
+    from:
+      - https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/mu-plugins/epfl-stats
+      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
+
+##################### "2018" plugins ###########################
 
 - name: '"TinyMCE Advanced" plugin'
   wordpress_plugin:

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -4,11 +4,6 @@ FROM ubuntu:bionic
 ENV PHP_VERSION=7.3
 ARG WORDPRESS_VERSION_LINEAGE=4.9
 
-# Travis-specific arguments — See ../../.travis.yml
-ARG GITHUB_API_USER
-ARG GITHUB_API_TOKEN
-ARG INSTALL_AUTO_FLAGS
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qy update && \
@@ -48,6 +43,9 @@ RUN apt-get -qy update && apt-get  -qy install --no-install-recommends \
 
 # Download latest WP-CLI in the 1.5.x branch (otherwise diggy/polylang-cli
 # won't install):
+# Travis-specific arguments — See ../../.travis.yml
+ARG GITHUB_API_USER
+ARG GITHUB_API_TOKEN
 RUN set -x;                                                              \
    curl -o /usr/local/bin/wp -L                                          \
         $(curl $(if [ -n "${GITHUB_API_TOKEN}" ]; then                   \
@@ -92,6 +90,7 @@ RUN set -e -x; cd /; git apply < /tmp/wordpress-anywhere.patch;          \
 
 ADD install-plugins-and-themes.py /tmp/
 # Get all plugins and themes ("auto" mode) from the jahia2wp manifest:
+ARG INSTALL_AUTO_FLAGS
 RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
 
 ######################################################################

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -293,7 +293,11 @@ class WpOpsPlugins:
             manifest_url = AUTO_MANIFEST_URL
 
         progress("Obtaining plug-in manifest from {}".format(manifest_url))
-        self.plugins_yaml = requests.get(manifest_url).content
+        req = requests.get(manifest_url)
+        if req.status_code != 200:
+            raise Exception('requests.get("{}") yielded status {}'.format(
+                manifest_url, req.status_code))
+        self.plugins_yaml = req.content
 
     def plugins(self):
         """Yield all the plug-ins to be installed according to the "ops" metadata."""

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -97,6 +97,7 @@ class GitHubCheckout:
         """
         self.url = url
         self._parsed = self._parse(url)
+        assert self._parsed
 
     @classmethod
     def is_valid(cls, url):
@@ -147,6 +148,7 @@ class GitHubCheckout:
                 self._git_topdir = self._clone_cache[(self.clone_url, self.branch)]
             else:
                 tmp = Tempdir()
+                progress("Cloning {}".format(self.clone_url))
                 run_cmd(["git", "clone", self.clone_url], cwd=str(tmp))
                 self._git_topdir = os.path.join(str(tmp), self.github_project)
                 if self.branch is not None:

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -370,6 +370,9 @@ if __name__ == '__main__':
 
     if flags.auto:
         manifest = WpOpsPlugins(flags.manifest_url)
+        for d in (WP_PLUGINS_INSTALL_DIR, WP_MU_PLUGINS_INSTALL_DIR):
+            if not os.path.isdir(d):
+                os.makedirs(d)
         for plugin in manifest.must_use_plugins():
             if plugin.name not in flags.exclude:
                 progress("Installing mu-plugin {}".format(plugin.name))

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -25,9 +25,9 @@ Usage:
 
   install-plugins-and-themes.py auto [options ...]
 
-    Install all plugins (and in the future, also mu-plugins and themes)
-    into /wp. The list and addresses of plugins to install is determined
-    from the current state of the source code.
+    Install all plugins, mu-plugins and themes into /wp. The list and
+    addresses of plugins to install is determined from the Ansible
+    configuration.
 
     Options:
 

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -55,7 +55,8 @@ Options:
 
 
 def progress(string):
-    print("# {}".format(string))
+    print("# {}".format(string), file=sys.stderr)
+    sys.stderr.flush()
 
 
 def run_cmd(cmd, *args, **kwargs):

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -170,8 +170,6 @@ class Plugin(object):
     def __init__(self, name, urls, **unused_kwargs):
         self.name = name
         self.urls = urls
-        if len(self.urls) == 1:
-            self.url = self.urls[0]
 
     def __new__(cls, name, urls):
         if cls is Plugin:
@@ -211,11 +209,13 @@ class ZipPlugin(Plugin):
 
     def __init__(self, name, urls, jahia2wp=None):
         super(ZipPlugin, self).__init__(name, urls)
+        assert len(self.urls) == 1
+        self.url = self.urls[0]
+        assert self.url.startswith("http")
         self.jahia2wp = jahia2wp
 
     def install(self, target_dir):
         """Unzip into a subdirectory `target_dir` named `self.name`."""
-        assert self.url.startswith("http")
         zip = ZipFile(io.BytesIO(requests.get(self.url).content))
 
         progress("Unzipping {}".format(self.url))


### PR DESCRIPTION
- `install-plugins.py` now can accept any number of mu-plugins from anywhere it does plugins
- The list is sourced from the Ansible state using the same technique as we previously did with plugins
- Still no effect Ansible-side
