### PR TITLE
Check that /keybase exists (rather than the keybase command-line tool)

### DIFF
--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -36,7 +36,7 @@ fatal () {
 }
 
 platform_check () {
-    which keybase >/dev/null || warn <<NO_KEYBASE
+    test -d /keybase/team || warn <<NO_KEYBASE
 
 WARNING: keybase is not installed, cannot decipher and push secrets.
 


### PR DESCRIPTION
I modified the script so that it tests the validated Keybase folder instead of just testing if the Keybase application is installed!