### PR TITLE
Add simple-sitemap plugin

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -250,6 +250,12 @@
     state: symlinked
     from: wordpress.org/plugins
 
+- name: simple-sitemap plugin
+  wordpress_plugin:
+    name: simple-sitemap
+    state: symlinked
+    from: wordpress.org/plugins
+
 - name: EPFL plugin
   wordpress_plugin:
     name: epfl


### PR DESCRIPTION
Used in a bunch of sites of /srv/subdomains — Currently causing a number of broken symlinks