### PR TITLE
Pin Polylang to a version before 2.6

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -113,7 +113,7 @@
   wordpress_plugin:
     name: polylang
     state: symlinked
-    from: wordpress.org/plugins
+    from: https://downloads.wordpress.org/plugin/polylang.2.5.2.zip
 
 - name: Coming Soon plugin
   wordpress_plugin:


### PR DESCRIPTION
Some hacks in epfl/menus/epfl-menus.php depend on internal details of
Poylang. This unintended upgrade broke all menus on www.epfl.ch
