### PR TITLE
Make /wp/4 exist

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -93,6 +93,10 @@ ADD install-plugins-and-themes.py /tmp/
 ARG INSTALL_AUTO_FLAGS
 RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
 
+# In the future, we will have support for multiple WordPress versions
+# in the image:
+RUN cd /wp; ln -s . 4
+
 ######################################################################
 # Manually override themes and plugins
 ######################################################################


### PR DESCRIPTION
This is known as DEV_WP_4_SYMLINK in http://go.epfl.ch/wp5-design-doc

The elegant thing would be to have /wp/4 be a directory; however,
given the current layout of symlinks on the NAS share, this is not
currently possible. The plan is therefore to

1. Push this here change to production
2. Resymlink all sites with a two-symlink scheme similar to the one
   Kubernetes uses for secrets and ConfigMaps
3. Do The Right Thing in the image