### PR TITLE
Walk higher up to find a wp-config.php

### DIFF
--- a/docker/wp-base/wordpress-anywhere.patch
+++ b/docker/wp-base/wordpress-anywhere.patch
@@ -1,10 +1,20 @@
 --- volumes/wp/wp-load.php.ORIG	2019-03-14 08:30:45.000000000 +0100
 +++ volumes/wp/wp-load.php	2019-03-14 08:52:13.000000000 +0100
-@@ -41,6 +41,31 @@
+@@ -31,6 +31,9 @@
+  *
+  * If neither set of conditions is true, initiate loading the setup process.
+  */
++
++$wp_config_loaded = FALSE;
++
+ if ( file_exists( ABSPATH . 'wp-config.php') ) {
+ 
+ 	/** The config file resides in ABSPATH */
+@@ -41,6 +44,31 @@
  	/** The config file resides one level above ABSPATH but is not part of another installation */
  	require_once( dirname( ABSPATH ) . '/wp-config.php' );
  
-+    $wp_config_loaded = 1;
++    $wp_config_loaded = TRUE;
 +
  } else {
  
@@ -16,7 +26,7 @@
 +        if ( @file_exists($wp_config = "$parentdir/wp-config.php" ) ) {
 +
 +            require_once( $wp_config );
-+            $wp_config_loaded = 1;
++            $wp_config_loaded = TRUE;
 +            break;
 +
 +        } else if ( FALSE !== @lstat( "$parentdir/wp-content" ) ) {

--- a/docker/wp-base/wordpress-anywhere.patch
+++ b/docker/wp-base/wordpress-anywhere.patch
@@ -1,13 +1,34 @@
 --- volumes/wp/wp-load.php.ORIG	2019-03-14 08:30:45.000000000 +0100
 +++ volumes/wp/wp-load.php	2019-03-14 08:52:13.000000000 +0100
-@@ -41,6 +41,10 @@
+@@ -41,6 +41,31 @@
  	/** The config file resides one level above ABSPATH but is not part of another installation */
  	require_once( dirname( ABSPATH ) . '/wp-config.php' );
  
-+} elseif ( @file_exists($wp_config = dirname($_SERVER["SCRIPT_FILENAME"]) . "/wp-config.php")) {
-+    require_once($wp_config);
-+} elseif ( @file_exists($wp_config = dirname(dirname($_SERVER["SCRIPT_FILENAME"])) . "/wp-config.php")) {
-+    require_once($wp_config);
++    $wp_config_loaded = 1;
++
  } else {
  
++    // Look for wp-config.php up the directory tree, up to a depth of
++    // 5 e.g. for wp-content/plugins/myplugin/inc/foo.php
++    for ( $depth = 1; $depth <= 5 ; $depth++ ) {
++
++        $parentdir = dirname( $_SERVER["SCRIPT_FILENAME"], $depth );
++        if ( @file_exists($wp_config = "$parentdir/wp-config.php" ) ) {
++
++            require_once( $wp_config );
++            $wp_config_loaded = 1;
++            break;
++
++        } else if ( FALSE !== @lstat( "$parentdir/wp-content" ) ) {
++
++            // We appear to have reached a WordPress top-level
++            // directory; stop here
++            break;
++
++        }
++    }
++}
++
++if ( ! $wp_config_loaded ) {
++
  	// A config file doesn't exist

--- a/docker/wp-base/wordpress-anywhere.patch
+++ b/docker/wp-base/wordpress-anywhere.patch
@@ -5,19 +5,17 @@
   * If neither set of conditions is true, initiate loading the setup process.
   */
 +
-+$wp_config_loaded = FALSE;
++$wp_config_loaded = TRUE;
 +
  if ( file_exists( ABSPATH . 'wp-config.php') ) {
  
  	/** The config file resides in ABSPATH */
-@@ -41,6 +44,31 @@
- 	/** The config file resides one level above ABSPATH but is not part of another installation */
- 	require_once( dirname( ABSPATH ) . '/wp-config.php' );
+@@ -43,4 +46,29 @@
  
-+    $wp_config_loaded = TRUE;
-+
  } else {
  
++    $wp_config_loaded = FALSE;
++
 +    // Look for wp-config.php up the directory tree, up to a depth of
 +    // 5 e.g. for wp-content/plugins/myplugin/inc/foo.php
 +    for ( $depth = 1; $depth <= 5 ; $depth++ ) {


### PR DESCRIPTION
This lets `require_once("wp_load.php");` do the right thing in a
symlinked site, also when invoked from a .php script up to one
directory deep inside a plug-in.

In turn, this will let us to improve on things like [jahia2wp#1037](https://github.com/epfl-idevelop/jahia2wp/pull/1037)