### PR TITLE
More prudent cleanup operations after symlinking

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -139,6 +139,7 @@
       do
           case "$path" in
               .ht*) continue ;;
+              *.ini) continue ;;
               wp-config.php|index.php) continue ;;
               {{ symlinks_all_paths | join('|') }}) continue ;;
           esac

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -122,7 +122,7 @@
     "INDEX_PHP_CHANGED" in _unsymlink_script.stdout or
     "NO_SYMLINKS" not in _unsymlink_script.stdout
 
-- name: "Clean up stale files on symlinked site"
+- name: "Verify that there are no stale files on symlinked site"
   tags: symlink
   check_mode: no
   shell:
@@ -150,11 +150,7 @@
               echo FILES_TRIMMED
               files_trimmed=1
           fi
-      {% if ansible_check_mode %}
           echo >&2 "$path needs trimming"
-      {% else %}
-          rm -f "$path"
-      {% endif %}
       done
   register: _symlink_cleanup_script
   changed_when: '"FILES_TRIMMED" in _symlink_cleanup_script.stdout'


### PR DESCRIPTION
- .ini files are OK
- In case other files are left over, signal them (by going orange) but don't erase them