### PR TITLE
Use code from our repo because plugin deleted from WordPress store

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -180,7 +180,7 @@
   wordpress_plugin:
     name: cache-control
     state: symlinked
-    from: wordpress.org/plugins
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/cache-control
 
 - name: Cache-Control options
   wordpress_option:


### PR DESCRIPTION
Le plugin cache-control a été supprimé du store WordPress le 5 juillet 2019 => https://fr.wordpress.org/plugins/cache-control/
Ceci entraine un problème de la création de l'image chaque nuit dans Jenkins. Afin de faire en sorte que cela continue à fonctionner, il a été choisi de récupérer le code du plugin (dans un autre site déjà déployé) et de l'intégrer dans le repo jahia2wp (via PR ).
Par la suite, il faudra définir si on continue avec ce code récupéré et plus maintenu ou si on trouve un autre plugin.
