### PR TITLE
Add Library specific plugin

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -450,3 +450,8 @@
     state: "{{ plugins_symlinked_in_scienceqa_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-scienceqa
 
+- name: EPFL-Library-Plugins plugin
+  wordpress_plugin:
+    name: EPFL-Library-Plugins
+    state: symlinked
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-Library-Plugins


### PR DESCRIPTION
- Suite à l'ajout du plugin spécifique à la bibliothèque dans le repo jahia2wp, ajout de celui-ci dans l'image wp-base

**Note**
L'image a été build en local afin de valider la chose.