### PR TITLE
Bugfix: clearstatcache() before reading file sizes

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -93,6 +93,8 @@ ADD install-plugins-and-themes.py /tmp/
 ARG INSTALL_AUTO_FLAGS
 RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
 
+
+
 # In the future, we will have support for multiple WordPress versions
 # in the image:
 RUN cd /wp; ln -s . 4
@@ -107,5 +109,10 @@ RUN cp /wp/wp-content/plugins/index.php /wp/wp-content/mu-plugins/index.php
 # For importing sites from the WXR XML format (e.g. "ventilation" operations)
 RUN cd /wp/wp-content/plugins;                                           \
     /tmp/install-plugins-and-themes.py wordpress-importer wordpress.org/plugins
+# Aaaaand nuke the stat() cache inbetween downloading things
+ADD clearstatcache-wp-import.patch /tmp/
+RUN set -e -x; cd /wp/wp-content/plugins/wordpress-importer;             \
+    git apply < /tmp/clearstatcache-wp-import.patch;                     \
+    rm /tmp/clearstatcache-wp-import.patch
 
 RUN rm -rf /tmp/install-plugins*

--- a/docker/wp-base/clearstatcache-wp-import.patch
+++ b/docker/wp-base/clearstatcache-wp-import.patch
@@ -1,0 +1,10 @@
+--- wordpress-importer.php.ORIG	2019-07-16 09:51:44.386308000 +0000
++++ wordpress-importer.php	2019-07-16 09:52:01.816308000 +0000
+@@ -1011,6 +1011,7 @@
+ 			return new WP_Error( 'import_file_error', sprintf( __('Remote server returned error response %1$d %2$s', 'wordpress-importer'), esc_html($remote_response_code), get_status_header_desc($remote_response_code) ) );
+ 		}
+ 
++		clearstatcache();
+ 		$filesize = filesize( $upload['file'] );
+ 
+ 		if ( isset( $headers['content-length'] ) && $filesize != $headers['content-length'] ) {


### PR DESCRIPTION
No idea why this worked before, or why it started failing - However,
in the current setup, all filesize() calls read out to zero, despite
the file having the correct size.