### PR TITLE
Use an environment variable (not command substitution) for HOSTNAME

### DIFF
--- a/docker/httpd/dyn-vhost.conf
+++ b/docker/httpd/dyn-vhost.conf
@@ -4,10 +4,10 @@ RemoteIPHeader X-Forwarded-For
 RemoteIPInternalProxy 172.31.0.0/16 10.180.21.0/24 127.0.0.0/8
 
 LogFormat "%V %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" \"%{X-EPFL-Trace-Id}i\" %{CF-Connecting-IP}i %T %D" vcommon
-CustomLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/access_log.$(hostname).%Y%m%d 86400" vcommon
+CustomLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/access_log.${HOSTNAME}.%Y%m%d 86400" vcommon
 CustomLog "/dev/stdout" vcommon
 
-ErrorLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/error_log.$(hostname).%Y%m%d 86400"
+ErrorLog "| /usr/bin/rotatelogs /srv/${WP_ENV}/logs/error_log.${HOSTNAME}.%Y%m%d 86400"
 
 VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"
 


### PR DESCRIPTION
This fixes a breakage introduced in
https://github.com/epfl-idevelop/wp-ops/commit/a4bc309e5913a1be950ab4703ad2b88140ff54aa
whereby all log files have a literal `$(hostname)` in the name.