### PR TITLE
 Support multiple versions of WordPress in one image 

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:bionic
 
 # Version pins are defined here:
 ENV PHP_VERSION=7.3
-ARG WORDPRESS_VERSION_LINEAGE=4.9
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,11 +40,17 @@ RUN apt-get -qy update && apt-get  -qy install --no-install-recommends \
     apt-get -qy autoremove && \
     apt-get clean
 
-# Download latest WP-CLI in the 1.5.x branch (otherwise diggy/polylang-cli
-# won't install):
+
+######################################################################
+# Install wp-cli
+######################################################################
+
 # Travis-specific arguments — See ../../.travis.yml
 ARG GITHUB_API_USER
 ARG GITHUB_API_TOKEN
+
+# Download latest WP-CLI in the 1.5.x branch (otherwise diggy/polylang-cli
+# won't install):
 RUN set -x;                                                              \
    curl -o /usr/local/bin/wp -L                                          \
         $(curl $(if [ -n "${GITHUB_API_TOKEN}" ]; then                   \
@@ -72,47 +77,79 @@ RUN su -s /bin/sh www-data -c " \
     wp package install https://github.com/epfl-idevelop/wp-cli.git;       \
     rm -f ~/.composer/auth.json"
 
-# Install a copy of WordPress into /wp, populate it with our plugins,
-# and patch it to support our symlink-based serving layout
-RUN mkdir /wp
-RUN wp --allow-root --path=/wp core download \
-  --version=$(curl https://api.wordpress.org/core/version-check/1.7/     \
+######################################################################
+# Install and patch WordPresses
+######################################################################
+# Install multiple versions of WordPress into /wp/, and patch them to
+# support our symlink-based serving layout
+ARG WORDPRESS_VERSION_LINEAGES="4.9 5.2"
+RUN set -x;                                                              \
+    for lineage in ${WORDPRESS_VERSION_LINEAGES}; do                     \
+        version=$(curl https://api.wordpress.org/core/version-check/1.7/ \
             | jq -r '.offers[].current                                   \
-                      | select(match("'${WORDPRESS_VERSION_LINEAGE}'"))' \
-            |sort -n -r |head -1)
+                      | select(match("'${lineage}'"))'                   \
+            |sort -n -r |head -1) ;                                      \
+        mkdir -p /wp/$version ;                                          \
+        wp --allow-root --path=/wp/$version                              \
+           core download --version=$version ;                            \
+    done
 
-RUN rm -rf /wp/wp-content/plugins/akismet /wp/wp-content/plugins/hello.php \
-    /wp/wp-content/themes/twenty*
+RUN rm -rf /wp/*/wp-content/plugins/akismet                              \
+          /wp/*/wp-content/plugins/hello.php                             \
+    /wp/*/wp-content/themes/twenty*
 
 ADD wordpress-anywhere.patch /tmp/
-RUN set -e -x; cd /; git apply < /tmp/wordpress-anywhere.patch;          \
+RUN set -e -x;                                                           \
+    apt -qy install patch;                                               \
+    for wp in /wp/*; do                                                  \
+        cd $wp ;                                                         \
+        patch -p0 -F3 < /tmp/wordpress-anywhere.patch;                   \
+    done;                                                                \
+    apt -qy remove --purge patch;                                        \
     rm /tmp/wordpress-anywhere.patch
 
-ADD install-plugins-and-themes.py /tmp/
-# Get all plugins and themes ("auto" mode) from the jahia2wp manifest:
+######################################################################
+# Install and patch plugins and themes
+######################################################################
+
+ADD install-plugins-and-themes.py clearstatcache-wp-import.patch /tmp/
+# Get all plugins and themes ("auto" mode) from the jahia2wp manifest;
 ARG INSTALL_AUTO_FLAGS
-RUN set -x; /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS}
+RUN set -e -x; for wp in /wp/*; do cd $wp ;                              \
+        /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS};   \
+    done
 
-
-
-# In the future, we will have support for multiple WordPress versions
-# in the image:
-RUN cd /wp; ln -s . 4
-
-######################################################################
-# Manually override themes and plugins
-######################################################################
-
-# Prevent directory listings in the mu-plugins/ subdirectories of sites:
-RUN cp /wp/wp-content/plugins/index.php /wp/wp-content/mu-plugins/index.php
-
-# For importing sites from the WXR XML format (e.g. "ventilation" operations)
-RUN cd /wp/wp-content/plugins;                                           \
-    /tmp/install-plugins-and-themes.py wordpress-importer wordpress.org/plugins
-# Aaaaand nuke the stat() cache inbetween downloading things
-ADD clearstatcache-wp-import.patch /tmp/
-RUN set -e -x; cd /wp/wp-content/plugins/wordpress-importer;             \
-    git apply < /tmp/clearstatcache-wp-import.patch;                     \
+# Manually add the wordpress-importer plugin, used in "ventilation"
+# operations. Patch it to nuke the stat() cache inbetween downloading
+# things
+RUN set -e -x; for wp in /wp/*; do                                       \
+        cd $wp/wp-content/plugins ;                                      \
+        /tmp/install-plugins-and-themes.py                               \
+            wordpress-importer wordpress.org/plugins ;                   \
+        cd wordpress-importer ;                                          \
+        git apply < /tmp/clearstatcache-wp-import.patch ;                \
+    done;                                                                \
     rm /tmp/clearstatcache-wp-import.patch
 
-RUN rm -rf /tmp/install-plugins*
+RUN rm /tmp/install-plugins-and-themes.py
+
+# Prevent directory listings in the mu-plugins/ subdirectories of sites:
+RUN set -e -x; for wp in /wp/*; do                                       \
+        cd $wp/wp-content ;                                              \
+        cp plugins/index.php mu-plugins/index.php ;                      \
+    done
+
+######################################################################
+# Symlinks
+######################################################################
+# Major version symlinks
+# We do that last for simplicity, at a small cost in build time
+RUN set -e -x; cd /wp; for version in *; do                              \
+        major="$(echo "$version" |cut -d. -f1)";                         \
+        rm -f "$major"; ln -s "$version" "$major";                       \
+    done
+
+# As a backward compatibility measure / temporary hack, we support
+# sites that symlink to /wp instead of /wp/4 or /wp/5:
+RUN set -e -x; cd /wp;                                                   \
+    for file_or_dir in 4/*; do ln -s $file_or_dir .; done

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
 
 # “The main PPA for supported PHP versions[...]”, see
 # https://launchpad.net/~ondrej/+archive/ubuntu/php
-RUN add-apt-repository ppa:ondrej/php
+RUN add-apt-repository ppa:ondrej/php; rm -rf /tmp/tmp*
 
 RUN apt-get -qy update && apt-get  -qy install --no-install-recommends \
     composer \

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -25,8 +25,9 @@ Usage:
 
   install-plugins-and-themes.py auto [options ...]
 
-    Install all plugins, mu-plugins and themes into /wp. The list and
-    addresses of plugins to install is determined from the Ansible
+    Install all plugins, mu-plugins and themes into the WordPress
+    instance rooted at the current directory. The list and addresses
+    of plugins to install is determined from the Ansible
     configuration.
 
     Options:
@@ -373,7 +374,7 @@ class Flags:
             self.path = argv[1]
 
 
-WP_INSTALL_DIR = '/wp/wp-content'
+WP_INSTALL_DIR = './wp-content'
 WP_PLUGINS_INSTALL_DIR = os.path.join(WP_INSTALL_DIR, 'plugins')
 WP_MU_PLUGINS_INSTALL_DIR = os.path.join(WP_INSTALL_DIR, 'mu-plugins')
 WP_THEMES_INSTALL_DIR = os.path.join(WP_INSTALL_DIR, 'themes')

--- a/docker/wp-base/wordpress-anywhere.patch
+++ b/docker/wp-base/wordpress-anywhere.patch
@@ -1,5 +1,5 @@
---- volumes/wp/wp-load.php.ORIG	2019-03-14 08:30:45.000000000 +0100
-+++ volumes/wp/wp-load.php	2019-03-14 08:52:13.000000000 +0100
+--- wp-load.php.ORIG	2019-08-15 12:55:06.030129000 +0000
++++ wp-load.php	2019-08-15 12:55:41.083793000 +0000
 @@ -31,6 +31,9 @@
   *
   * If neither set of conditions is true, initiate loading the setup process.
@@ -10,7 +10,7 @@
  if ( file_exists( ABSPATH . 'wp-config.php') ) {
  
  	/** The config file resides in ABSPATH */
-@@ -43,4 +46,29 @@
+@@ -43,6 +46,31 @@
  
  } else {
  
@@ -40,3 +40,5 @@
 +if ( ! $wp_config_loaded ) {
 +
  	// A config file doesn't exist
+ 
+ 	define( 'WPINC', 'wp-includes' );


### PR DESCRIPTION
Layout is like

```
/wp
|-- 4 -> 4.9.10
|-- 4.9.10
|   |-- index.php
|   |.......
|-- 5 -> 5.2.2
|-- 5.2.2
|   |.......
```
(more in the commit messages)

- Use `patch` instead of `git apply`, because someone did a one-line
  cosmetic change in WordPress branch 5.x in the vicinity of where
  `wordpress-anywhere.patch` used to apply cleanly
- Patch the patch to support `patch -p0`
- Turn a bunch of RUN commands into `for` loops, so as to accomodate
  `WORDPRESS_VERSION_LINEAGES` now being plural
