### PR TITLE
Bugfix: serving off stale PHP code when updating symlinks

### DIFF
--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -3,3 +3,7 @@
 ;; In a symlinked serving environment, the realpath cache is a pure
 ;; liability - disable it and rely on the NFS attribute cache instead.
 realpath_cache_size = 0M
+
+;; We want to be able to atomically update symlinks, without the PHP opcache
+;; getting in the way.
+opcache.revalidate_path = 1


### PR DESCRIPTION
As a DevOps operator, we want to be able to move from e.g. WordPress 4 to WordPress 5 by atomically mutating one symlink. The only thing that stands in the way of that goal after #103  is that PHP won't seem to revalidate some kind of cache until we restart Apache.

- Found poorly documented `opcache.revalidate_path` that sounds related to the issue at hand
- Looked at source code, sorta willing to believe that this could do the trick
- Let's find out by merging this PR and see what happens to the QA rig
