### PR TITLE
Revert "Set opcache.revalidate_path = 1"

### DIFF
--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -3,7 +3,3 @@
 ;; In a symlinked serving environment, the realpath cache is a pure
 ;; liability - disable it and rely on the NFS attribute cache instead.
 realpath_cache_size = 0M
-
-;; We want to be able to atomically update symlinks, without the PHP opcache
-;; getting in the way.
-opcache.revalidate_path = 1


### PR DESCRIPTION
This reverts commit b0ede35906c37e75ca4a1d381efc2c560e12e206 (aka #104)

After further testing, it turns out that the culprit is not the
opcache, but rather, the NFS client cache. We can make this work with
no changes to php.ini.