### PR TITLE
`wpsible -t symlink` mainstreaming

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -141,6 +141,8 @@ sub as_ansible_hostvars {
     $k =~ s/^ssh_/ansible_/;
     $retval->{$k} = $v || '';
   }
+  $retval->{openshift_namespace} = "wwp-prod";
+  $retval->{openshift_dc} = "httpd-" . $retval->{wp_env};
   # TODO: should be 5.2 once #108 has been pushed to staging.
   $retval->{wp_ensure_symlink_version} = "5";
   return $retval;

--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -141,6 +141,8 @@ sub as_ansible_hostvars {
     $k =~ s/^ssh_/ansible_/;
     $retval->{$k} = $v || '';
   }
+  # TODO: should be 5.2 once #108 has been pushed to staging.
+  $retval->{wp_ensure_symlink_version} = "5";
   return $retval;
 }
 

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -143,6 +143,8 @@ sub as_ansible_hostvars {
     $k =~ s/^ssh_/ansible_/;
     $retval->{$k} = $v || '';
   }
+  $retval->{openshift_namespace} = "wwp-test";
+  $retval->{openshift_dc} = "httpd-" . $retval->{wp_env};
   if (($wp->{wp_hostname} eq 'migration-wp.epfl.ch') &&
         $wp->{wp_path} =~ /^labs/)
     {

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -143,6 +143,12 @@ sub as_ansible_hostvars {
     $k =~ s/^ssh_/ansible_/;
     $retval->{$k} = $v || '';
   }
+  if (($wp->{wp_hostname} eq 'migration-wp.epfl.ch') &&
+        $wp->{wp_path} =~ /^labs/)
+    {
+      # TODO: should be 5.2 once #108 has been pushed to staging.
+      $retval->{wp_ensure_symlink_version} = "5";
+    }
   return $retval;
 }
 

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -40,10 +40,9 @@
   command: "{{ wp_cli_command }} eval '1;'"
   changed_when: false
 
-- name: "Set up / revert “symlink” serving discipline"
-  when: wp_can.configure or ansible_check_mode
+- name: "Set up “symlink” serving discipline"
+  when: (wp_can.configure or ansible_check_mode) and wp_ensure_symlink_version is defined
   tags:
-    - never
     - symlink
     - unsymlink
   # We include_tasks (not import_tasks) here, because we do *not* want

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -24,7 +24,7 @@
 
 # It never hurts to have a working "wp" symlink at the top level of
 # the WordPress site, so do this first:
-- name: "Version-specific symlink to /wp"
+- name: "“Main” symlink to /wp"
   tags: symlink
   check_mode: no   # Does The Right Thing under ansible-playbook --check
   when: wp_ensure_symlink_version is defined

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -22,6 +22,31 @@
   set_fact:
     wp_is_symlinked: '{{ "symlink" in ansible_run_tags }}'
 
+- name: "Version-specific symlink to /wp"
+  tags: symlink
+  check_mode: no   # Does The Right Thing under ansible-playbook --check
+  when: wp_ensure_symlink_version is defined
+  shell:
+    cmd: |
+      {{ lookup("template", "symlinks-lib.sh") }}
+
+      cd "{{ wp_dir }}"
+      target="/wp/{{ wp_ensure_symlink_version }}"
+      [ "$(readlink "wp" 2>/dev/null || true)" = "$target" ] && return 0
+
+      echo SYMLINK_CHANGED
+      {% if ansible_check_mode %}
+      echo >&2 "$PWD/wp points to $(readlink "wp"); $target expected"
+      {% else %}
+      tmpdir="$(mktemp -d ./tmpnewsymlink-XXXXXX)"
+      (cd "$tmpdir"; ln -s "$target" wp)
+      mv "$tmpdir"/wp .
+      rmdir "$tmpdir"
+      {% endif %}
+  register: _main_symlink_script
+  changed_when: >
+    "SYMLINK_CHANGED" in _main_symlink_script.stdout
+
 # WP_CONTENT_DIR can be set in wp-config.php prior to symlinking
 # without ill effects:
 - name: "Reconfigure wp-config.php before symlinking"
@@ -31,9 +56,9 @@
     apply:
       tags: ["symlink"]
 
-- name: "Symlink"
+- name: "Symlink pieces of the WordPress core"
   tags: symlink
-  check_mode: no   # Does The Right Thing under ansible-playbook --check
+  check_mode: no
   shell:
     cmd: |
       {{ lookup("template", "symlinks-lib.sh") }}
@@ -42,10 +67,11 @@
       set -e -x
       cd {{ wp_dir }}
 
+      if make_symlinks_to_wp --check {{ symlinks_all_paths | join(" ") }}; then exit; else :; fi
+
       {% if not ansible_check_mode %}
       enter_maintenance_mode
       trap leave_maintenance_mode EXIT HUP INT QUIT
-      {% endif %}
 
       if make_symlinks_to_wp {{ symlinks_all_paths | join(" ") }}; then :; else
           case "$?" in
@@ -65,6 +91,7 @@
               *) exit $?                ;;
           esac
       fi
+      {% endif %}
   register: _symlink_script
   changed_when: >
     "SYMLINKS_CHANGED" in _symlink_script.stdout or

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -55,7 +55,6 @@
     _main_symlink_script is changed
   shell:
     cmd: |
-      dc=httpd-int
       for pod in $(oc get pods -n "{{ openshift_namespace }}" -o json \
                    | jq -r \
                        '.items

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -56,13 +56,18 @@
   tags: symlink
   when: >
     _main_symlink_script is changed
-  shell:
+  local_action:
+    module: shell
     cmd: |
+      set -o pipefail
+      set -e # -x
       for pod in $(oc get pods -n "{{ openshift_namespace }}" -o json \
                    | jq -r \
                        '.items
-                        | map("'"{{ openshift_dc }}"'" ==
-                             select(.metadata.annotations["openshift.io/deployment-config.name"]))
+                        | map(select(
+                            "'"{{ openshift_dc }}"'" ==
+                            .metadata.annotations["openshift.io/deployment-config.name"]
+                             ))
                         | map(.metadata.name) | .[]')
       do
         oc exec -n "{{ openshift_namespace }}" -c "{{ openshift_container_name }}" -it $pod -- ls -l "{{ wp_dir }}"

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -22,6 +22,8 @@
   set_fact:
     wp_is_symlinked: '{{ "symlink" in ansible_run_tags }}'
 
+# It never hurts to have a working "wp" symlink at the top level of
+# the WordPress site, so do this first:
 - name: "Version-specific symlink to /wp"
   tags: symlink
   check_mode: no   # Does The Right Thing under ansible-playbook --check
@@ -46,6 +48,23 @@
   register: _main_symlink_script
   changed_when: >
     "SYMLINK_CHANGED" in _main_symlink_script.stdout
+
+- name: "Invalidate serving pods' NFS cache entries for the main symlink"
+  tags: symlink
+  when: >
+    _main_symlink_script is changed
+  shell:
+    cmd: |
+      dc=httpd-int
+      for pod in $(oc get pods -n "{{ openshift_namespace }}" -o json \
+                   | jq -r \
+                       '.items
+                        | map("'"{{ openshift_dc }}"'" ==
+                             select(.metadata.annotations["openshift.io/deployment-config.name"]))
+                        | map(.metadata.name) | .[]')
+      do
+        oc exec -n "{{ openshift_namespace }}" -c "{{ openshift_dc }}" -it $pod -- ls -l "{{ wp_dir }}"
+      done
 
 # WP_CONTENT_DIR can be set in wp-config.php prior to symlinking
 # without ill effects:

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -17,6 +17,9 @@
 - include_vars: symlink-vars.yml
   tags: always
 
+- include_vars: openshift-vars.yml
+  tags: always
+
 - name: "Set wp_is_symlinked"
   tags: always
   set_fact:
@@ -62,7 +65,7 @@
                              select(.metadata.annotations["openshift.io/deployment-config.name"]))
                         | map(.metadata.name) | .[]')
       do
-        oc exec -n "{{ openshift_namespace }}" -c "{{ openshift_dc }}" -it $pod -- ls -l "{{ wp_dir }}"
+        oc exec -n "{{ openshift_namespace }}" -c "{{ openshift_container_name }}" -it $pod -- ls -l "{{ wp_dir }}"
       done
 
 # WP_CONTENT_DIR can be set in wp-config.php prior to symlinking


### PR DESCRIPTION
- `symlink.yml` is no longer guarded by `tags: never`. Instead of conscious operator action, what decides whether a site needs its symlinks checked on a regular basis is now its so-called “hostvars”, set by the inventory script
- Hard-code the set of such sites to be all of `www`, `labs` and `inside` DeploymentConfigs in production, as well as those sites in `subdomains` that use the `epfl-light` theme; and sites under `migration-wp.epfl.ch/htdocs/labs` on the test platform
- Don't enter maintenance mode anymore when there is no need to do so
- Treat the “main” symlink (the `wp → /wp/4` one at the WordPress site's top level) specially; set it up first (before the other ones); update it atomically (and thus, don't enter maintenance mode); revalidate NFS cache thereof on the serving pods (the latter is as simple as `readlink(2)` a.k.a. `ls -l` — See #110, a.k.a. unreverting #104, for a lengthy explanation)
