### PR TITLE
Bugfix: serving off stale PHP code when updating symlinks 

### DIFF
--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -3,3 +3,7 @@
 ;; In a symlinked serving environment, the realpath cache is a pure
 ;; liability - disable it and rely on the NFS attribute cache instead.
 realpath_cache_size = 0M
+
+;; We want to be able to atomically update symlinks, without the PHP opcache
+;; getting in the way.
+opcache.revalidate_path = 1


### PR DESCRIPTION
This brings back #104 by reverting #105 a.k.a. commit cd6f9b5ea75a79a1fa605a6b32fbebd6e56a9f42.

Soooooo... It looks like this change, *together* with NFS symlink
revalidation, is what makes atomic updates of the `wp` symlink work.

The reproduction method is as follows:

<ol>
<li> Create script `wp-content/uploads/wpversion.php` that goes like
<pre>
&lt;?php

require_once( &lowbar;&lowbar;DIR&lowbar;&lowbar; . '/../../wp-load.php' );

echo "\$wp_version = $wp_version\n";
echo "\$wp_db_version = $wp_db_version\n";
</pre></li>
<li> Have it continually queried with `curl`, e.g. <pre>
uri=https://migration-wp.epfl.ch/labs/dcsl/wp-content/uploads/wpversion.php
while sleep 1; do (set -x; curl -sS -H "Cache-Control: no-cache" $uri ) ; done
</pre></li>
<li> Update the main symlink (the one whose name is <code>wp</code> at the root of
the WordPress instance under test)</li>
<li> Revalidate the main symlink in the NFS cache of all
serving hosts (using <code>readlink(2)</code> a.k.a. <code>ls -l</code>)</li>
</ol>

Some observations performed today, for archaeological purposes:

-  Without this patch: it takes several minutes for PHP to figure out
that the main symlink, and hence all of WordPress, changed
- With this patch: the change is instant as soon as the
`oc exec -it YADDAYADDA ls -l /srv/int/FOO/BAR` commands complete
- With `opcache.enable = 0` instead of `opcache.revalidate_path = 1`:
same results, except the serving time of what is basically a no-op
WordPress load, doubles (from 0.25 seconds to 0.5 seconds — Finger-in-the-air measurement on unspecified back-end specs and NFS latency, YMMV)
- If you omit step 4: the wrong WP version situation persists for no
longer than 60 seconds, a.k.a. `acregmax` / `acdirmax` in
https://linux.die.net/man/5/nfs