### PR TITLE
Manage plug-ins with Ansible

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -143,8 +143,7 @@ sub as_ansible_hostvars {
   }
   $retval->{openshift_namespace} = "wwp-prod";
   $retval->{openshift_dc} = "httpd-" . $retval->{wp_env};
-  # TODO: should be 5.2 once #108 has been pushed to staging.
-  $retval->{wp_ensure_symlink_version} = "5";
+  $retval->{wp_ensure_symlink_version} = "5.2";
   return $retval;
 }
 

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -148,8 +148,7 @@ sub as_ansible_hostvars {
   if (($wp->{wp_hostname} eq 'migration-wp.epfl.ch') &&
         $wp->{wp_path} =~ /^labs/)
     {
-      # TODO: should be 5.2 once #108 has been pushed to staging.
-      $retval->{wp_ensure_symlink_version} = "5";
+      $retval->{wp_ensure_symlink_version} = "5.2";
     }
   return $retval;
 }

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -1,6 +1,75 @@
 from ansible.plugins.action import ActionBase
-
+from ansible.errors import AnsibleActionFail
+from ansible.module_utils import six
 
 class ActionModule(ActionBase):
-    def run(self, tmp=None, task_vars=None):
-        return super(ActionModule, self).run(tmp, task_vars)
+    def run (self, tmp=None, task_vars=None):
+        self.result = super(ActionModule, self).run(tmp, task_vars)
+        self._tmp = tmp
+        self._task_vars = task_vars
+
+        args = self._task.args
+        desired_state = args.get('state', 'absent')
+        if isinstance(desired_state, six.string_types):
+            desired_state = desired_state.strip()
+
+        name = args.get('name')
+
+        current_state = self._get_plugin_state(name)
+        if (desired_state == current_state):
+            pass
+        elif (desired_state == 'absent' and current_state != 'absent'):
+            self.result.update(self._do_uninstall_plugin(name))
+        elif ('must-use' in desired_state):
+            pass  # TODO later - The `wp plugin install` command cannot help us here
+        elif (desired_state == 'symlinked' and current_state != 'symlinked'):
+            self.result.update(self._do_symlink_plugin(name))
+        else:
+            raise AnsibleActionFail('Cannot transition plugin %s from state %s to %s' %
+                                    (name, current_state, desired_state))
+
+        return self.result
+
+    def _get_plugin_state (self, name):
+        plugin_stat = self._run_action(
+            'stat',
+            {
+             'path': '%s/wp-content/plugins/%s' % (self._get_ansible_var('wp_dir'), name)
+             })
+        if 'failed' in plugin_stat:
+            return plugin_stat
+        elif not ('stat' in plugin_stat and plugin_stat['stat']['exists']):
+            return 'absent'
+        elif plugin_stat['stat']['islnk']:
+            return 'symlinked'
+        else:
+            # TODO: should distinguish between "installed" and "active"
+            return 'installed'
+
+    def _do_uninstall_plugin (self, name):
+        return self._run_wp_cli_action('plugin uninstall %s' % name)
+
+    def _do_symlink_plugin (self, name):
+        return self._run_wp_cli_action('plugin install %s' % name)
+
+    def _run_wp_cli_action (self, args):
+        return self._run_shell_action(
+            '%s %s' % (self._get_ansible_var('wp_cli_command'), args))
+
+    def _run_shell_action (self, cmd):
+        return self._run_action('command', { '_raw_params': cmd, '_uses_shell': True })
+
+    def _run_action(self, action_name, args):
+        # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins
+        # at § “Action Plugins”
+        return self._execute_module(module_name=action_name,
+                                    module_args=args, tmp=self._tmp, task_vars=self._task_vars)
+
+    def _get_ansible_var (self, name):
+        unexpanded = self._task_vars.get(name, None)
+        if unexpanded is None:
+            return None
+        else:
+            return self._templar.template(unexpanded)
+
+

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -18,12 +18,21 @@ class ActionModule(ActionBase):
         current_state = self._get_plugin_state(name)
         if (desired_state == current_state):
             pass
-        elif (desired_state == 'absent' and current_state != 'absent'):
+        elif desired_state == 'absent':
             self.result.update(self._do_uninstall_plugin(name))
         elif ('must-use' in desired_state):
             pass  # TODO later - The `wp plugin install` command cannot help us here
-        elif (desired_state == 'symlinked' and current_state != 'symlinked'):
+        elif 'symlinked' in desired_state:
+            if current_state != 'absent' and 'symlinked' not in current_state:
+                self.result.update(self._do_rimraf_plugin(name))
+                if 'failed' in self.result: return result
+
             self.result.update(self._do_symlink_plugin(name))
+            if 'failed' in self.result: return result
+            
+            if ('failed' not in self.result) and (desired_state != 'symlinked-inactive'):
+                self.result.update(self._do_activate_plugin(name))
+                
         else:
             raise AnsibleActionFail('Cannot transition plugin %s from state %s to %s' %
                                     (name, current_state, desired_state))
@@ -34,23 +43,44 @@ class ActionModule(ActionBase):
         plugin_stat = self._run_action(
             'stat',
             {
-             'path': '%s/wp-content/plugins/%s' % (self._get_ansible_var('wp_dir'), name)
+             'path': self._get_plugin_path(name)
              })
-        if 'failed' in plugin_stat:
-            return plugin_stat
-        elif not ('stat' in plugin_stat and plugin_stat['stat']['exists']):
+        if 'failed' in plugin_stat: return plugin_stat
+
+        if not ('stat' in plugin_stat and plugin_stat['stat']['exists']):
             return 'absent'
         elif plugin_stat['stat']['islnk']:
-            return 'symlinked'
+            if self._is_plugin_active(name):
+                return 'symlinked'
+            else:
+                return 'symlinked-inactive'
         else:
-            # TODO: should distinguish between "installed" and "active"
-            return 'installed'
+            if self._is_plugin_active(name):
+                return 'active'
+            else:
+                return 'installed'
 
     def _do_uninstall_plugin (self, name):
-        return self._run_wp_cli_action('plugin uninstall %s' % name)
+        result = self._run_wp_cli_action('plugin deactivate %s' % name)
+        if 'failed' not in result:
+            result.update(self._do_rimraf_plugin(name))
+        return result
 
     def _do_symlink_plugin (self, name):
-        return self._run_wp_cli_action('plugin install %s' % name)
+        return self._run_action('file', {
+            'state': 'link',
+            'src': '../../wp/wp-content/plugins/%s' % name,
+            'path': '%s/wp-content/plugins/%s' % (self._get_wp_dir(), name),
+            })
+
+    def _do_activate_plugin (self, name):
+        return self._run_wp_cli_action('plugin activate %s' % name)
+
+    def _do_rimraf_plugin (self, name):
+        return self._run_action(
+            'file',
+            {'state': 'absent',
+             'path': self._get_plugin_path(name)}) 
 
     def _run_wp_cli_action (self, args):
         return self._run_shell_action(
@@ -59,11 +89,21 @@ class ActionModule(ActionBase):
     def _run_shell_action (self, cmd):
         return self._run_action('command', { '_raw_params': cmd, '_uses_shell': True })
 
-    def _run_action(self, action_name, args):
+    def _run_action (self, action_name, args):
         # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins
         # at § “Action Plugins”
         return self._execute_module(module_name=action_name,
                                     module_args=args, tmp=self._tmp, task_vars=self._task_vars)
+
+    def _get_wp_dir (self):
+        return self._get_ansible_var('wp_dir')
+
+    def _get_plugin_path (self, name):
+        return '%s/wp-content/plugins/%s' % (self._get_wp_dir(), name)
+
+    def _is_plugin_active (self, name):
+        result = self._run_wp_cli_action('plugin status %s' % name)
+        return (result and 'Status: Active' in result.get('stdout', ''))
 
     def _get_ansible_var (self, name):
         unexpanded = self._task_vars.get(name, None)

--- a/ansible/roles/wordpress-instance/tasks/configure.yml
+++ b/ansible/roles/wordpress-instance/tasks/configure.yml
@@ -16,6 +16,18 @@
     line: |
       define('WP_CONTENT_DIR', '{{ wp_dir }}/wp-content');
 
+- name: Detect whether a WordPress database update is needed
+  shell: '{{ wp_cli_command }} core update-db --dry-run'
+  changed_when: false
+  register: _wp_core_db_update_dry_run
+
+- name: Do WordPress database update
+  shell:
+    cmd: |
+      {{ wp_cli_command }} core update-db
+  when: >
+    "already" not in _wp_core_db_update_dry_run.stdout
+
 - name: Check whether ping_sites is set
   command: "{{ wp_cli_command }} option get ping_sites"
   changed_when: false

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -10,7 +10,11 @@
 
 - name: WordPress facts
   import_tasks: facts.yml
-  tags: facts
+  tags:
+    - facts
+    # TODO: configure.yml uses wp_is_symlinked, which requires facts.yml to have run.
+    # Can we use a handler instead?
+    - config
 
 - name: Backup
   import_tasks: "backup.yml"

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -259,14 +259,14 @@
 - name: EPFL plugin
   wordpress_plugin:
     name: epfl
-    state: >
+    state: >-
       {{ "absent" if plugins_use_wp2010_plugins else "symlinked" }}
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
 
 - name: EPFL Gutenberg plugin
   wordpress_plugin:
     name: wp-gutenberg-epfl
-    state: >
+    state: >-
       {{ "symlinked" if plugins_use_gutenberg else "absent" }}
     from: https://github.com/epfl-idevelop/wp-gutenberg-epfl
 

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -33,6 +33,7 @@
   when: wp_ensure_symlink_version is defined
   shell:
     cmd: |
+      set -e -x
       cd "{{ wp_dir }}"
       target="/wp/{{ wp_ensure_symlink_version }}"
       [ "$(readlink "wp" 2>/dev/null || true)" = "$target" ] && return 0
@@ -58,7 +59,7 @@
     module: shell
     cmd: |
       set -o pipefail
-      set -e # -x
+      set -e -x
       for pod in $(oc get pods -n "{{ openshift_namespace }}" -o json \
                    | jq -r \
                        '.items

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -33,8 +33,6 @@
   when: wp_ensure_symlink_version is defined
   shell:
     cmd: |
-      {{ lookup("template", "symlinks-lib.sh") }}
-
       cd "{{ wp_dir }}"
       target="/wp/{{ wp_ensure_symlink_version }}"
       [ "$(readlink "wp" 2>/dev/null || true)" = "$target" ] && return 0

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -92,13 +92,13 @@
       set -e -x
       cd {{ wp_dir }}
 
-      if make_symlinks_to_wp --check {{ symlinks_all_paths | join(" ") }}; then exit; else :; fi
+      if make_symlinks_to_wp --check {{ symlinks_managed_in_bulk | join(" ") }}; then exit; else :; fi
 
       {% if not ansible_check_mode %}
       enter_maintenance_mode
       trap leave_maintenance_mode EXIT HUP INT QUIT
 
-      if make_symlinks_to_wp {{ symlinks_all_paths | join(" ") }}; then :; else
+      if make_symlinks_to_wp {{ symlinks_managed_in_bulk | join(" ") }}; then :; else
           case "$?" in
               1) echo "SYMLINKS_CHANGED" ;;
               *) exit $?                 ;;
@@ -193,7 +193,7 @@
               .ht*) continue ;;
               *.ini) continue ;;
               wp-config.php|index.php) continue ;;
-              {{ symlinks_all_paths | join('|') }}) continue ;;
+              {{ symlinks_managed_in_bulk | join('|') }}) continue ;;
           esac
           if [ ! -e "$path" ]; then continue; fi
           if [ -d "$path" ]; then continue; fi

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -9,7 +9,7 @@ plugins_use_Restauration: false
 plugins_use_ScienceQA: false
 plugins_use_CDHSHS: false
 plugins_use_Library: false
-plugins_use_gutenberg: '{{ (wp_ensure_symlink_version is defined) and (wp_ensure_symlink_version > 4) }}'
+plugins_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_symlink_version | float) >= 5.0 }}'
 
 plugins_symlinked_in_2010_only: '{{ "symlinked" if plugins_use_wp2010_plugins else "absent" }}'
 plugins_symlinked_in_emploi_only: '{{ "symlinked" if plugins_use_Emploi else "absent" }}'

--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -16,48 +16,6 @@ symlinks_paths_wp:
   - wp-content/themes/index.php
   - wp-content/mu-plugins/index.php
 
-symlinks_plugins:
-  - EPFL-Content-Filter
-  - EPFL-settings
-  - accred
-  - cache-control
-  - epfl
-  - epfl-404
-  - ewww-image-optimizer
-  - feedzy-rss-feeds
-  - mainwp-child
-  - pdfjs-viewer-shortcode
-  - polylang
-  - remote-content-shortcode
-  - shortcode-ui
-  - shortcode-ui-richtext
-  - simple-sitemap
-  - svg-support
-  - tequila
-  - tinymce-advanced
-  - varnish-http-purge
-  - very-simple-meta-description
-  - wp-media-folder
-  # "2010" plugins:
-  - EPFL-Share
-  - epfl-scheduler
-  - epfl-news
-  - epfl-memento
-  - epfl-faq
-  - epfl-map
-  - epfl-buttons
-  - epfl-snippet
-  - epfl-toggle
-  - epfl-grid
-  - epfl-infoscience
-  - epfl-infoscience-search
-  - epfl-xml
-  - epfl-people
-  - epfl-twitter
-  - epfl-video
-  - epfl-tableau
-  - epfl-google-forms
-
 symlinks_themes:
   - epfl-blank
   - epfl-master
@@ -99,9 +57,8 @@ _symlinks_muplugins_yaml: |
 
 symlinks_muplugins: "{{ _symlinks_muplugins_yaml | from_yaml }}"
 
-symlinks_all_paths: >
+symlinks_managed_in_bulk: >
   {{ symlinks_paths_wp
-    + ('wp-content/plugins/%s'    | map_format(symlinks_plugins))
     + ('wp-content/mu-plugins/%s' | map_format(symlinks_muplugins))
     + ('wp-content/themes/%s'     | map_format(symlinks_themes))
   }}


### PR DESCRIPTION
... And do so correctly in the face of the upcoming transition to WP 5.x.

- Flesh out the `wordpress_plugin` custom action, so that it now honors `state: symlinked` or `state: absent` (`state: must-use`  is still to-do)
- Stop managing the symlinks in `wp-content/plugins` as part of the main WP install in `symlink.yml`, now that `plugins.yml` takes care of it.

Demo:
<pre>wpsible -l migration-wp-labs-dcsl -t symlink,config,plugins -e '{"wp_destructive": {"migration-wp-labs-dcsl": "config"}}' -v</pre>
<pre>wpsible -l migration-wp-labs-dcsl -t symlink,config,plugins -e '{"wp_destructive": {"migration-wp-labs-dcsl": "config"}, "wp_ensure_symlink_version": "4"}'</pre>

