### PR TITLE
Implement `-t backup.code`, etc. as subsets of `-t backup`

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -4,18 +4,28 @@
   command: mktemp -d -p {{ wp_dir }} -t ansible-backup-XXXXXX
   changed_when: false
   register: _backup_tmpdir_cmd
+  tags: always
 
 - set_fact:
     _backup_tmpdir: "{{ _backup_tmpdir_cmd.stdout }}"
+  tags: always
 
 - name: Back up code to {{ _backup_tmpdir }} — 💡 In case of a catastrophe, you will find your files there.
   shell: |
     set -e
     (cd "{{ wp_dir }}"; tar --exclude wp-content/uploads -clf - .) | \
       (cd "{{ _backup_tmpdir }}"; tar xpvf -)
+  tags:
+    - wipe
+    - backup
+    - backup.code
 
 - name: Back up data to {{ _backup_tmpdir }} — 💡 In case of a catastrophe, you will find your files there.
   command: "{{ wp_cli_command }} db export {{ _backup_tmpdir }}/backup.sql"
+  tags:
+    - wipe
+    - backup
+    - backup.data
 
 - name: Back up uploads to {{ _backup_tmpdir }} — 💡 In case of a catastrophe, you will find your files there.
   shell: |
@@ -23,3 +33,7 @@
     cd "{{ wp_dir }}"
     mkdir -p "{{ _backup_tmpdir }}"/wp-content || true
     cp -a wp-content/uploads {{ _backup_tmpdir }}/wp-content
+  tags:
+    - wipe
+    - backup
+    - backup.uploads

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -17,12 +17,20 @@
     - config
 
 - name: Backup
-  import_tasks: "backup.yml"
+  # We include_tasks (not import_tasks) here, because we do *not* want
+  # to propagate tags - Within backup.yml, tasks shall be individually
+  # marked with the appropriate subset of the `backup.code`,
+  # `backup.data` and `backup.uploads` tags (or alternatively, the
+  # `always` tag).
+  include_tasks: "backup.yml"
   tags:
-    - never  # That is, skip unless "-t backup" or "-t wipe" is
+    - never  # That is, skip unless "-t wipe", "-t backup", "-t backup.code" etc. is
              # passed on the command line
     - wipe
     - backup
+    - backup.code
+    - backup.data
+    - backup.uploads
 
 - name: Wipe
   import_tasks: "wipe.yml"
@@ -49,10 +57,10 @@
   tags:
     - symlink
     - unsymlink
-  # We include_tasks (not import_tasks) here, because we do *not* want
-  # to propagate tags - Within symlink.yml, tasks shall be
-  # individually marked with either (or both) the `symlink` and
-  # `unsymlink` tags (or alternatively, the `always` tag).
+  # Like for backup.yml above, we include_tasks (not import_tasks)
+  # here, so as *not* to auto-propagate tags. Tasks within symlink.yml
+  # must pay close attention to their tag set (and thus properly
+  # segregate the `-t symlink` and `-t unsymlink` use cases)
   include_tasks: "symlink.yml"
 
 - name: Configure


### PR DESCRIPTION
As per today's discussion in the daily stand-up, `-t backup.data` will come in handy soon. (`-t backup` was already working, but we don't want to waste the time and disk space.)