### PR TITLE
Fix up wp_destructive requirements for symlinking

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -53,7 +53,9 @@
   changed_when: false
 
 - name: "Set up “symlink” serving discipline"
-  when: (wp_can.configure or ansible_check_mode) and wp_ensure_symlink_version is defined
+  when:
+    - wp_ensure_symlink_version is defined
+    - (wp_can.configure and wp_can.write_code) or ansible_check_mode
   tags:
     - symlink
     - unsymlink

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -10,6 +10,10 @@
 # Being (or not being) a symlinked site also has consequences w.r.t.
 # templated configuration files; see configure.yml for details.
 
+- assert:
+    that:
+      - (wp_can.configure and wp_can.write_code) or ansible_check_mode
+
 # Required by _symlinks_muplugins_yaml in symlink-vars.yml:
 - include_vars: category-vars.yml
   tags: always
@@ -124,7 +128,6 @@
 
 - name: "Unsymlink (copy from /wp)"
   tags: unsymlink
-  when: wp_can.configure or ansible_check_mode
   check_mode: no
   shell:
     cmd: |


### PR DESCRIPTION
The truth is that symlinking *will* destroy code e.g. if you have a site whose PHP has been hand-edited, then those changes will be rolled back.

One must now say

```
"wp_destructive": {"migration-wp-labs-dcsl": "config,code"},       # ...
```

instead of just

<s><pre>"wp_destructive": {"migration-wp-labs-dcsl": "config"},     # ...</pre></s>