### PR TITLE
Hoist `openshift_dc` from inventory to `openshift-vars.yml`

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -142,7 +142,6 @@ sub as_ansible_hostvars {
     $retval->{$k} = $v || '';
   }
   $retval->{openshift_namespace} = "wwp-prod";
-  $retval->{openshift_dc} = "httpd-" . $retval->{wp_env};
   $retval->{wp_ensure_symlink_version} = "5.2";
   return $retval;
 }

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -144,7 +144,6 @@ sub as_ansible_hostvars {
     $retval->{$k} = $v || '';
   }
   $retval->{openshift_namespace} = "wwp-test";
-  $retval->{openshift_dc} = "httpd-" . $retval->{wp_env};
   if (($wp->{wp_hostname} eq 'migration-wp.epfl.ch') &&
         $wp->{wp_path} =~ /^labs/)
     {

--- a/ansible/roles/wordpress-instance/vars/openshift-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/openshift-vars.yml
@@ -1,1 +1,2 @@
+openshift_dc: "httpd-{{ wp_env }}"
 openshift_container_name: "{{ openshift_dc }}"


### PR DESCRIPTION
This way, all Wordpress instances (including those from [branch `feature/wp-int`](https://github.com/epfl-idevelop/wp-ops/tree/feature/wp-int)) have an `openshift_dc`.