### PR TITLE
Distinguish "symlinked" from "active" in plugins.yml

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -89,7 +89,8 @@ class ActionModule(ActionBase):
         activation_state = self._desired_activation_state(desired_state)
 
         if 'absent' == installation_state and activation_state:
-            raise ValueError('Plug-in %s cannot be simultaneously absent and %s' % activation_state)
+            raise ValueError('Plug-in %s cannot be simultaneously absent and %s' %
+                             (name, activation_state))
 
         return desired_state
 
@@ -106,7 +107,8 @@ class ActionModule(ActionBase):
         elif len(installation_state) == 1:
             return list(installation_state)[0]
         else:
-            raise ValueError('Plug-in %s cannot be simultaneously %s' % list(installation_state))
+            raise ValueError('Plug-in %s cannot be simultaneously %s' % (
+                name, list(installation_state)))
 
     def _desired_activation_state(self, desired_state):
         activation_state = desired_state.intersection(['active', 'inactive', 'must-use'])
@@ -115,7 +117,8 @@ class ActionModule(ActionBase):
         elif len(activation_state) == 1:
             return list(activation_state)[0]
         else:
-            raise ValueError('Plug-in %s cannot be simultaneously %s' % list(activation_state))
+            raise ValueError('Plug-in %s cannot be simultaneously %s' %
+                             (name, list(activation_state)))
 
     def _do_symlink_plugin (self, name, is_mu):
         return self._run_action('file', {

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -192,5 +192,17 @@ class ActionModule(ActionBase):
             return self._templar.template(unexpanded)
 
     def _update_result (self, result):
+        oldresult = copy.copy(self.result)
         self.result.update(result)
+
+        def _keep_flag(flag_name):
+            if (flag_name in oldresult and
+                oldresult[flag_name] and
+                flag_name in self.result and
+                not result[flag_name]
+            ):
+                self.result[flag_name] = oldresult[flag_name]
+
+        _keep_flag('changed')
+                
         return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import re
 
 from ansible.plugins.action import ActionBase
@@ -148,8 +149,11 @@ class ActionModule(ActionBase):
             name)
 
     def _get_plugin_activation_state (self, name):
+        oldresult = copy.copy(self.result)
         result = self._run_wp_cli_action('plugin list --format=csv')
         for line in result.splitlines()[1:]:
+
+        self.result = oldresult  # We don't want "changed" to pollute the state
             fields = line.split(',')
             if len(line) < 2: continue
             if line[0] == name: return line[1]

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import copy
+# There is a name clash with a module in Ansible named "copy":
+deepcopy = __import__('copy').deepcopy
 import re
 
 from ansible.plugins.action import ActionBase
@@ -177,7 +178,7 @@ class ActionModule(ActionBase):
             name)
 
     def _get_plugin_activation_state (self, name):
-        oldresult = copy.copy(self.result)
+        oldresult = deepcopy(self.result)
         result = self._run_wp_cli_action('plugin list --format=csv')
         if 'failed' in self.result: return self.result
 
@@ -197,7 +198,7 @@ class ActionModule(ActionBase):
             return self._templar.template(unexpanded)
 
     def _update_result (self, result):
-        oldresult = copy.copy(self.result)
+        oldresult = deepcopy(self.result)
         self.result.update(result)
 
         def _keep_flag(flag_name):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -39,20 +39,20 @@ class ActionModule(ActionBase):
 
 
         if cares_about_activation_state and 'active' in to_undo:
-            self.result.update(self._do_deactivate_plugin(name))
+            self._update_result(self._do_deactivate_plugin(name))
             if 'failed' in self.result: return self.result
 
         if  cares_about_installation_state and (
                 'symlinked' in to_undo or 'installed' in to_undo):
-            self.result.update(self._do_rimraf_plugin(name))
+            self._update_result(self._do_rimraf_plugin(name))
             if 'failed' in self.result: return self.result
 
         if cares_about_installation_state and 'symlinked' in to_do:
-            self.result.update(self._do_symlink_plugin(name, 'must-use' in desired_state))
+            self._update_result(self._do_symlink_plugin(name, 'must-use' in desired_state))
             if 'failed' in self.result: return self.result
 
         if cares_about_activation_state and 'active' in to_do:
-            self.result.update(self._do_activate_plugin(name))
+            self._update_result(self._do_activate_plugin(name))
             if 'failed' in self.result: return self.result
 
         return self.result
@@ -107,6 +107,7 @@ class ActionModule(ActionBase):
             return list(installation_state)[0]
         else:
             raise ValueError('Plug-in %s cannot be simultaneously %s' % list(installation_state))
+
     def _desired_activation_state(self, desired_state):
         activation_state = desired_state.intersection(['active', 'inactive', 'must-use'])
         if len(activation_state) == 0:
@@ -152,7 +153,7 @@ class ActionModule(ActionBase):
         result = self._execute_module(module_name=action_name,
                                       module_args=args, tmp=self._tmp,
                                       task_vars=self._task_vars)
-        self.result.update(result)
+        self._update_result(result)
         return self.result
 
     def _get_wp_dir (self):
@@ -190,4 +191,6 @@ class ActionModule(ActionBase):
         else:
             return self._templar.template(unexpanded)
 
-
+    def _update_result (self, result):
+        self.result.update(result)
+        return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -151,12 +151,14 @@ class ActionModule(ActionBase):
     def _get_plugin_activation_state (self, name):
         oldresult = copy.copy(self.result)
         result = self._run_wp_cli_action('plugin list --format=csv')
-        for line in result.splitlines()[1:]:
+        if 'failed' in self.result: return self.result
 
         self.result = oldresult  # We don't want "changed" to pollute the state
+
+        for line in result["stdout"].splitlines()[1:]:
             fields = line.split(',')
-            if len(line) < 2: continue
-            if line[0] == name: return line[1]
+            if len(fields) < 2: continue
+            if fields[0] == name: return fields[1]
         return 'inactive'
 
     def _get_ansible_var (self, name):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -24,6 +24,12 @@ class ActionModule(ActionBase):
         cares_about_installation_state = bool(self._desired_installation_state(desired_state))
         cares_about_activation_state = bool(self._desired_activation_state(desired_state))
 
+        if 'must-use' in desired_state:
+            # TODO — UNIMPLEMENTED Some must-use plug-ins have two
+            # files to symlink, and the structure of the code doesn't
+            # allow for that yet.
+            return self.result
+
         if not (to_do or to_undo):
             return self.result
 

--- a/ansible/roles/wordpress-instance/tasks/generate.yml
+++ b/ansible/roles/wordpress-instance/tasks/generate.yml
@@ -12,6 +12,6 @@
   register: jahia2wp_generate_yaml_tmp
 
 - name: jahia2wp.py generate
-  shell: "{{ jahia2wp_shell }} generate {{ wp_env }} https://{{ wp_hostname }}/{{ wp_path }} --extra-config={{ jahia2wp_generate_yaml_tmp.dest }}"
+  shell: "{{ jahia2wp_shell }} generate {{ wp_env }} {{ jahia2wp_url }} --extra-config={{ jahia2wp_generate_yaml_tmp.dest }}"
   environment: "{{ jahia2wp_env }}"
  

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -473,7 +473,7 @@
 - name: epfl-intranet plugin
   wordpress_plugin:
     name: epfl-intranet
-    state: "{{ plugins_symlinked_in_inside_only }}"
+    state: "{{ plugins_symlinked_and_active_in_inside_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-intranet
 
 - name: epfl-emploi plugin

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -142,7 +142,9 @@
 - name: Tequila plugin
   wordpress_plugin:
     name: tequila
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-sti/wordpress.plugin.tequila/archive/vpsi.zip
 
 - name: Replace WP login screen with redirect-to-Tequila flow
@@ -158,7 +160,9 @@
 - name: Accred plugin
   wordpress_plugin:
     name: accred
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
 
 - name: accred administrator group
@@ -179,7 +183,9 @@
 - name: Cache-Control plugin
   wordpress_plugin:
     name: cache-control
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/cache-control
 
 - name: Cache-Control options
@@ -266,14 +272,18 @@
 - name: EPFL Gutenberg plugin
   wordpress_plugin:
     name: wp-gutenberg-epfl
-    state: >-
-      {{ "symlinked" if plugins_use_gutenberg else "absent" }}
+    state:
+      - symlinked
+      - >-
+        {{ "active" if plugins_use_gutenberg else "inactive" }}
     from: https://github.com/epfl-idevelop/wp-gutenberg-epfl
 
 - name: wp-media-folder plugin
   wordpress_plugin:
     name: wp-media-folder
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://wp-manager.epfl.ch/resources/plugin-zip/wp-media-folder.zip
 
 - name: wp-media-folder options
@@ -283,7 +293,9 @@
 - name: pdfjs-viewer-shortcode plugin
   wordpress_plugin:
     name: pdfjs-viewer-shortcode
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: very-simple-meta-description plugin
@@ -295,13 +307,17 @@
 - name: epfl-404 plugin
   wordpress_plugin:
     name: epfl-404
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-404
 
 - name: ewww-image-optimizer plugin
   wordpress_plugin:
     name: ewww-image-optimizer
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: ewww-image-optimizer configuration

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -106,13 +106,17 @@
 - name: '"TinyMCE Advanced" plugin'
   wordpress_plugin:
     name: tinymce-advanced
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: Polylang plugin
   wordpress_plugin:
     name: polylang
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://downloads.wordpress.org/plugin/polylang.2.5.2.zip
 
 - name: Coming Soon plugin
@@ -128,7 +132,9 @@
 - name: mainwp-child plugin
   wordpress_plugin:
     name: mainwp-child
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: mainwp_child_uniqueId option
@@ -201,13 +207,14 @@
 - name: varnish-http-purge plugin
   wordpress_plugin:
     name: varnish-http-purge
-    state: symlinked
-    from: wordpress.org/plugins
+    state: absent
 
 - name: EPFL-settings plugin
   wordpress_plugin:
     name: EPFL-settings
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-settings
 
 - name: custom_breadcrumb option for EPFL-settings plugin
@@ -218,13 +225,16 @@
 - name: EPFL-Content-Filter plugin
   wordpress_plugin:
     name: EPFL-Content-Filter
-    state: '{{ "symlinked" if plugins_locked else "absent" }}'
+    state: '{{ ["symlinked", "active"] if plugins_locked else "absent" }}'
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-Content-Filter
 
+# TODO: we are not quite sure anymore whether this plugin is useful.
 - name: svg-support plugin
   wordpress_plugin:
     name: svg-support
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: Dismiss svg-support popup
@@ -232,41 +242,35 @@
     name: bodhi_svgs_admin_notice_dismissed
     value: 1
 
-- name: feedzy-rss-feeds plugin
-  wordpress_plugin:
-    name: feedzy-rss-feeds
-    state: symlinked
-    from: wordpress.org/plugins
-
 - name: remote-content-shortcode plugin
   wordpress_plugin:
     name: remote-content-shortcode
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/remote-content-shortcode
 
 - name: shortcode-ui plugin
   wordpress_plugin:
     name: shortcode-ui
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: shortcode-ui-richtext plugin
   wordpress_plugin:
     name: shortcode-ui-richtext
-    state: symlinked
-    from: wordpress.org/plugins
-
-- name: simple-sitemap plugin
-  wordpress_plugin:
-    name: simple-sitemap
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: EPFL plugin
   wordpress_plugin:
     name: epfl
     state: >-
-      {{ "absent" if plugins_use_wp2010_plugins else "symlinked" }}
+      {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
 
 - name: EPFL Gutenberg plugin
@@ -281,27 +285,28 @@
 - name: wp-media-folder plugin
   wordpress_plugin:
     name: wp-media-folder
-    state:
-      - symlinked
-      - active
+    state: >-
+      {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
     from: https://wp-manager.epfl.ch/resources/plugin-zip/wp-media-folder.zip
 
 - name: wp-media-folder options
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_wpmf_options }}"
 
+# TODO: We are not sure what is up with WP5 and this one.
 - name: pdfjs-viewer-shortcode plugin
   wordpress_plugin:
     name: pdfjs-viewer-shortcode
     state:
       - symlinked
-      - active
     from: wordpress.org/plugins
 
 - name: very-simple-meta-description plugin
   wordpress_plugin:
     name: very-simple-meta-description
-    state: symlinked
+    state:
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: epfl-404 plugin
@@ -327,139 +332,155 @@
 
 ##################### 2010-only plugins ###########################
 
+# These plugins only exist in obsolescent DeploymentConfig's ("unm-*"
+# and "subdomains"). Holding off using Ansible on these is an
+# acceptable medium-term workaround measure.
+
+- name: feedzy-rss-feeds plugin
+  wordpress_plugin:
+    name: feedzy-rss-feeds
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
+    from: wordpress.org/plugins
+
+- name: simple-sitemap plugin
+  wordpress_plugin:
+    name: simple-sitemap
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
+    from: wordpress.org/plugins
+
 - name: EPFL-Share plugin
   wordpress_plugin:
     name: EPFL-Share
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/EPFL-Share
 
 - name: Shortcodes Ultimate plugin
   wordpress_plugin:
     name: shortcodes-ultimate
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: wordpress.org/plugins
 
 - name: Enlighter plugin
   wordpress_plugin:
     name: enlighter
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: wordpress.org/plugins
 
 - name: epfl-scheduler plugin
   wordpress_plugin:
     name: epfl-scheduler
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-scheduler
 
 - name: epfl-news plugin
   wordpress_plugin:
     name: epfl-news
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-news
 
 - name: epfl-memento plugin
   wordpress_plugin:
     name: epfl-memento
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-memento
 
 - name: epfl-faq plugin
   wordpress_plugin:
     name: epfl-faq
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-faq
 
 - name: epfl-map plugin
   wordpress_plugin:
     name: epfl-map
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-map
 
 - name: epfl-buttons plugin
   wordpress_plugin:
     name: epfl-buttons
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-buttons
 
 - name: epfl-snippet plugin
   wordpress_plugin:
     name: epfl-snippet
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-snippet
 
 - name: epfl-toggle plugin
   wordpress_plugin:
     name: epfl-toggle
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-toggle
 
 - name: epfl-grid plugin
   wordpress_plugin:
     name: epfl-grid
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-grid
 
 - name: epfl-infoscience plugin
   wordpress_plugin:
     name: epfl-infoscience
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience
 
 - name: epfl-infoscience-search plugin
   wordpress_plugin:
     name: epfl-infoscience-search
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience-search
 
 - name: epfl-xml plugin
   wordpress_plugin:
     name: epfl-xml
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-xml
 
 - name: epfl-people plugin
   wordpress_plugin:
     name: epfl-people
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-people
 
 - name: epfl-twitter plugin
   wordpress_plugin:
     name: epfl-twitter
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-twitter
 
 - name: epfl-video plugin
   wordpress_plugin:
     name: epfl-video
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-video
 
 - name: epfl-tableau plugin
   wordpress_plugin:
     name: epfl-tableau
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-tableau
 
 - name: epfl-google-forms plugin
   wordpress_plugin:
     name: epfl-google-forms
-    state: "{{ plugins_symlinked_in_2010_only }}"
+    state: "{{ plugins_symlinked_and_active_in_2010_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-google-forms
 
 ##################### Category-specific plugins ###########################
-
-- name: epfl-emploi plugin
-  wordpress_plugin:
-    name: epfl-emploi
-    state: "{{ plugins_symlinked_in_emploi_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-emploi
 
 - name: epfl-intranet plugin
   wordpress_plugin:
     name: epfl-intranet
     state: "{{ plugins_symlinked_in_inside_only }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-intranet
+
+- name: epfl-emploi plugin
+  wordpress_plugin:
+    name: epfl-emploi
+    state: "{{ plugins_symlinked_in_emploi_only }}"
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-emploi
 
 - name: epfl-restauration plugin
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -14,11 +14,11 @@ plugins_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_s
 # TODO: Likewise, these should be computed from wp-veritas state. We
 # set them to true out of an abundance of caution, and refrain from
 # managing their active / inactive state.
-plugins_use_Emploi: true
-plugins_use_Restauration: true
-plugins_use_ScienceQA: true
-plugins_use_Library: true
-plugins_use_CDHSHS: true
+plugins_use_Emploi: '{{ inventory_hostname == "www-about-working" }}'
+plugins_use_Restauration: '{{ inventory_hostname == "www-campus-restaurants-shops-hotels" }}'
+plugins_use_ScienceQA: '{{ inventory_hostname == "www" }}'
+plugins_use_Library: '{{ inventory_hostname == "www-campus-library" }}'
+plugins_use_CDHSHS: '{{ inventory_hostname == "www-schools-cdh" }}'
 
 plugins_symlinked_in_emploi_only: '{{ "symlinked" if plugins_use_Emploi else "absent" }}'
 plugins_symlinked_in_restauration_only: '{{ "symlinked" if plugins_use_Restauration else "absent" }}'

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -1,24 +1,28 @@
 # Plugin variables go here
 
 # TODO: These should be computed from wp-veritas state
-plugins_locked: true
-plugins_use_wp2010_plugins: false
-plugins_use_Emploi: false
-plugins_use_Inside: false
-plugins_use_Restauration: false
-plugins_use_ScienceQA: false
-plugins_use_CDHSHS: false
-plugins_use_Library: false
+plugins_locked: true                # TODO: should be false for unmanaged sites
+plugins_use_wp2010_plugins: false   # TODO: should be someething like '{{ wp_env == 'subdomains' }}" once camptocamp's INF-4475 (and the follow-up tasks on our side) are done
+plugins_use_Inside: '{{ wp_env == "inside" }}'
+
+plugins_symlinked_and_active_in_2010_only: '{{ ["symlinked", "active"] if plugins_use_wp2010_plugins else "absent" }}'
+plugins_symlinked_and_active_in_inside_only: '{{ ["symlinked", "active"] if plugins_use_Inside else "absent" }}'
 plugins_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_symlink_version | float) >= 5.0 }}'
 
-plugins_symlinked_in_2010_only: '{{ ["symlinked", "active"] if plugins_use_wp2010_plugins else "absent" }}'
-plugins_symlinked_in_emploi_only: '{{ ["symlinked", "active"] if plugins_use_Emploi else "absent" }}'
-plugins_symlinked_in_inside_only: '{{ ["symlinked", "active"] if plugins_use_Inside else "absent" }}'
-plugins_symlinked_in_restauration_only: '{{ ["symlinked", "active"] if plugins_use_Restauration else "absent" }}'
-plugins_symlinked_in_scienceqa_only: '{{ ["symlinked", "active"] if plugins_use_ScienceQA else "absent" }}'
-plugins_symlinked_in_cdhshs_only: '{{ ["symlinked", "active"] if plugins_use_CDHSHS else "absent" }}'
-plugins_symlinked_in_library_only: '{{ ["symlinked", "active"] if plugins_use_Library else "absent" }}'
+# TODO: Likewise, these should be computed from wp-veritas state. We
+# set them to true out of an abundance of caution, and refrain from
+# managing their active / inactive state.
+plugins_use_Emploi: true
+plugins_use_Restauration: true
+plugins_use_ScienceQA: true
+plugins_use_Library: true
+plugins_use_CDHSHS: true
 
+plugins_symlinked_in_emploi_only: '{{ "symlinked" if plugins_use_Emploi else "absent" }}'
+plugins_symlinked_in_restauration_only: '{{ "symlinked" if plugins_use_Restauration else "absent" }}'
+plugins_symlinked_in_scienceqa_only: '{{ "symlinked" if plugins_use_ScienceQA else "absent" }}'
+plugins_symlinked_in_library_only: '{{ "symlinked" if plugins_use_Library else "absent" }}'
+plugins_symlinked_in_cdhshs_only: '{{ "symlinked" if plugins_use_CDHSHS else "absent" }}'
 
 plugin_mainwp_child_uniqueid: "WinterIsComing"
 

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -2,7 +2,9 @@
 
 # TODO: These should be computed from wp-veritas state
 plugins_locked: true                # TODO: should be false for unmanaged sites
-plugins_use_wp2010_plugins: false   # TODO: should be someething like '{{ wp_env == 'subdomains' }}" once camptocamp's INF-4475 (and the follow-up tasks on our side) are done
+plugins_use_wp2010_plugins: '{{ wp_env == 'subdomains' }}"   # TODO: the accuracy (and innocuity!) of this
+                                                             # is pending camptocamp's INF-4475 (and the follow-up
+                                                             # tasks on our side)
 plugins_use_Inside: '{{ wp_env == "inside" }}'
 
 plugins_symlinked_and_active_in_2010_only: '{{ ["symlinked", "active"] if plugins_use_wp2010_plugins else "absent" }}'

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -11,13 +11,13 @@ plugins_use_CDHSHS: false
 plugins_use_Library: false
 plugins_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_symlink_version | float) >= 5.0 }}'
 
-plugins_symlinked_in_2010_only: '{{ "symlinked" if plugins_use_wp2010_plugins else "absent" }}'
-plugins_symlinked_in_emploi_only: '{{ "symlinked" if plugins_use_Emploi else "absent" }}'
-plugins_symlinked_in_inside_only: '{{ "symlinked" if plugins_use_Inside else "absent" }}'
-plugins_symlinked_in_restauration_only: '{{ "symlinked" if plugins_use_Restauration else "absent" }}'
-plugins_symlinked_in_scienceqa_only: '{{ "symlinked" if plugins_use_ScienceQA else "absent" }}'
-plugins_symlinked_in_cdhshs_only: '{{ "symlinked" if plugins_use_CDHSHS else "absent" }}'
-plugins_symlinked_in_library_only: '{{ "symlinked" if plugins_use_Library else "absent" }}'
+plugins_symlinked_in_2010_only: '{{ ["symlinked", "active"] if plugins_use_wp2010_plugins else "absent" }}'
+plugins_symlinked_in_emploi_only: '{{ ["symlinked", "active"] if plugins_use_Emploi else "absent" }}'
+plugins_symlinked_in_inside_only: '{{ ["symlinked", "active"] if plugins_use_Inside else "absent" }}'
+plugins_symlinked_in_restauration_only: '{{ ["symlinked", "active"] if plugins_use_Restauration else "absent" }}'
+plugins_symlinked_in_scienceqa_only: '{{ ["symlinked", "active"] if plugins_use_ScienceQA else "absent" }}'
+plugins_symlinked_in_cdhshs_only: '{{ ["symlinked", "active"] if plugins_use_CDHSHS else "absent" }}'
+plugins_symlinked_in_library_only: '{{ ["symlinked", "active"] if plugins_use_Library else "absent" }}'
 
 
 plugin_mainwp_child_uniqueid: "WinterIsComing"


### PR DESCRIPTION
This fixes the bug whence every site one ran Ansible on, would go into "coming soon" mode.

- Develop wordpress_plugin.py to distinguish "installation" desired state (e.g. `absent`, `installed` and `symlinked`) and "activation" desired state (`active`, `inactive`) in the `state: ` task argument
- Fully support `state: ` being a list
- Use set arithmetic to find out what is to be done
- Cut corners by refusing to install without symlinks (so that we don't have to fiddle with `wp plugin install` for now), and doing nothing on must-use plugins (because some of ours use more than one top-level file)