### PR TITLE
Shell script to create a WordPress site

### DIFF
--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     mysql-client \
     openssh-server \
     tree \
+    pwgen \
     python3 \
     python3-pip \
     python3-virtualenv \
@@ -35,6 +36,8 @@ RUN mkdir /var/run/sshd && \
     mkdir /root/.ssh
 
 COPY jahia2wp.sh /etc/profile.d/
+COPY new-wp-site.sh /usr/local/bin/new-wp-site
+RUN chmod a+x /usr/local/bin/new-wp-site
 COPY ./docker-entrypoint.sh /
 
 # setup access rights

--- a/docker/mgmt/new-wp-site.sh
+++ b/docker/mgmt/new-wp-site.sh
@@ -16,6 +16,8 @@ USAGE
 }
 
 main() {
+    check_env_prereqs
+
     ( set -x; wp --path=. core symlink --path_to_version="/wp/$WORDPRESS_VERSION" )
 
     if [ -f wp-config.php ]; then

--- a/docker/mgmt/new-wp-site.sh
+++ b/docker/mgmt/new-wp-site.sh
@@ -24,7 +24,7 @@ main() {
     else
         db_name="wp_$(mkid 29)"
         db_user="$(mkid 16)"
-        db_password="$(mkpass 20)"
+        db_pass="$(mkpass 20)"
         # `wp config create` doesn't care whether the credentials work or not
         ( set -x;
           wp --path=. config create --dbname="$db_name" --dbuser="$db_user" --dbpass="$db_pass" \
@@ -49,7 +49,7 @@ SQL_CREATE_USER
         ( set -x;
           wp core install --url="http://$wp_hostname/$wp_path" \
              --title="$(basename "$(pwd)")" \
-             --admin_user=admin --admin_email=admin@example.com \
+             --admin_user="$WP_ADMIN_USER" --admin_email="$WP_ADMIN_EMAIL" \
              --wpversion="$WORDPRESS_VERSION"
         )
     fi
@@ -102,8 +102,10 @@ MESSAGE
 }
 
 check_env_prereqs() {
-    [ -n "$MYSQL_SUPER_USER" ] || whine_env "MYSQL_SUPER_USER" 
-    [ -n "$MYSQL_SUPER_PASSWORD" ] || whine_env "MYSQL_SUPER_PASSWORD" 
+    [ -n "$MYSQL_SUPER_USER" ] || whine_env "MYSQL_SUPER_USER"
+    [ -n "$MYSQL_SUPER_PASSWORD" ] || whine_env "MYSQL_SUPER_PASSWORD"
+    [ -n "$WP_ADMIN_USER" ] || whine_env "WP_ADMIN_USER"
+    [ -n "$WP_ADMIN_EMAIL" ] || whine_env "WP_ADMIN_EMAIL"
 }
 
 do_mysql() {

--- a/docker/mgmt/new-wp-site.sh
+++ b/docker/mgmt/new-wp-site.sh
@@ -24,10 +24,10 @@ main() {
     else
         db_name="wp_$(mkid 29)"
         db_user="$(mkid 16)"
-        db_pass="$(mkpass 20)"
+        db_password="$(mkpass 20)"
         # `wp config create` doesn't care whether the credentials work or not
         ( set -x;
-          wp --path=. config create --dbname="$db_name" --dbuser="$db_user" --dbpass="$db_pass" \
+          wp --path=. config create --dbname="$db_name" --dbuser="$db_user" --dbpass="$db_password" \
              --dbhost=db --skip-check
         )
     fi

--- a/docker/mgmt/new-wp-site.sh
+++ b/docker/mgmt/new-wp-site.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+set -e
+
+: ${WORDPRESS_VERSION:=5.2}
+
+usage() {
+    die <<USAGE
+
+Create a symlinked WordPress site into the current directory.
+
+Usage: new-wp-site.sh
+
+USAGE
+
+}
+
+main() {
+    (set -x; wp --path=. core symlink --path_to_version="/wp/$WORDPRESS_VERSION")
+
+    if [ -f wp-config.php ]; then
+        # Retrieve DB credentials from wp-config.php
+        eval "$(perl -ne 'm/(DB_(NAME|USER|PASSWORD)).*, '\''(.*)'\''/ && print lc($1) . "=$3\n";' < wp-config.php)"
+    else
+        db_name="wp_$(mkid 29)"
+        db_user="$(mkid 16)"
+        db_password="$(mkpass 20)"
+        # `wp config create` doesn't care whether the credentials work or not
+        (set -x;
+         wp --path=. config create --dbname="$db_name" --dbuser="$db_user" --dbpass="$db_pass" \
+           --dbhost=db --skip-check)
+    fi
+
+    (set -x; wp db create --dbuser="$MYSQL_SUPER_USER" --dbpass="$MYSQL_SUPER_PASSWORD") || true
+
+    echo "DROP USER '$db_user';" | do_mysql || true
+    do_mysql <<SQL_CREATE_USER
+CREATE USER '$db_user'@'%' IDENTIFIED BY '$db_password';
+GRANT ALL PRIVILEGES ON $db_name.* TO '$db_user'@'%';
+FLUSH PRIVILEGES;
+SQL_CREATE_USER
+}
+
+###############################################################################
+
+die () {
+    if [ -n "$1" ]; then
+        echo >&2 "$@"
+    else
+        cat >&2
+    fi
+    exit 2
+}
+
+check_env() {
+    if [ -z "$MYSQL_SUPER_USER" -o -z "$MYSQL_SUPER_PASSWORD" ]; then
+        die <<MISSING_ENV
+Fatal: either MYSQL_SUPER_USER or MYSQL_SUPER_PASSWORD are unset.
+
+Please source the appropriate .env file and try again.
+
+MISSING_ENV
+    fi
+}
+
+mkpass() {
+    local length=$1
+    pwgen -s "$length" -n 1
+}
+
+mkid() {
+    local length=$1
+    while true; do
+        local id="$(mkpass $length | tr 'A-Z' 'a-z')"
+        case "$id" in
+            [a-z]*) echo "$id"; return 0;;
+        esac
+    done
+}
+
+whine_env() {
+    die <<MESSAGE
+Variable $1 is unset. Please source the appropriate .env file and try again.
+
+MESSAGE
+}
+
+check_env_prereqs() {
+    [ -n "$MYSQL_SUPER_USER" ] || whine_env "MYSQL_SUPER_USER" 
+    [ -n "$MYSQL_SUPER_PASSWORD" ] || whine_env "MYSQL_SUPER_PASSWORD" 
+}
+
+do_mysql() {
+    tee /dev/stderr | (set -x; mysql -h db -u "$MYSQL_SUPER_USER" -p"$MYSQL_SUPER_PASSWORD")
+}
+
+main


### PR DESCRIPTION
- Pros: takes no parameters
- Cons: doesn't install any plugin, mu-plugin etc. (That is the job of Ansible)
- Where: in `/usr/local/bin` of the mgmt image (so that if you don't want to use it, you don't have to)
- Why: first use-case is for [wp-dev](https://github.com/epfl-idevelop/wp-dev), but we can also actually create sites with this.

Features:
- repeatable
    - every destructive step controls whether it needs doing
    - credentials are persisted in `wp-config.php` even before the database is created, and retrieved from there if the script fails mid-way (which it shouldn't)
- URL and site title are guessed from the EPFL directory layout
- creates actual, working admin user (should be removed later e.g. after installing EPFL Tequila plug-in)
