### PR TITLE
[wait] Activate epfl menus in gutenberg

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -281,10 +281,8 @@
 - name: EPFL Menus plugin
   wordpress_plugin:
     name: epfl-menus
-    state:
-      - symlinked
-      - >-
-        {{ "active" if plugins_use_gutenberg else "inactive" }}
+    state: >-
+        {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-menus
 
 - name: wp-media-folder plugin

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -269,13 +269,6 @@
         {{ "inactive" if plugins_use_gutenberg else "active" }}
     from: wordpress.org/plugins
 
-- name: EPFL plugin
-  wordpress_plugin:
-    name: epfl
-    state: >-
-      {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
-
 - name: EPFL Gutenberg plugin
   wordpress_plugin:
     name: wp-gutenberg-epfl

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -269,6 +269,14 @@
         {{ "inactive" if plugins_use_gutenberg else "active" }}
     from: wordpress.org/plugins
 
+- name: EPFL plugin
+  wordpress_plugin:
+    name: epfl
+    state: >-
+      {{ [ "symlinked", "active" ] if plugins_use_gutenberg else "absent" }}
+    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
+
+
 - name: EPFL Gutenberg plugin
   wordpress_plugin:
     name: wp-gutenberg-epfl

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -273,7 +273,7 @@
   wordpress_plugin:
     name: epfl
     state: >-
-      {{ [ "symlinked", "active" ] if plugins_use_gutenberg else "absent" }}
+      {{ "absent" if plugins_use_gutenberg else [ "symlinked", "active" ]  }}
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
 
 

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -290,7 +290,8 @@
     name: epfl-menus
     state:
       - symlinked
-      - inactive
+      - >-
+        {{ "active" if plugins_use_gutenberg else "inactive" }}
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-menus
 
 - name: wp-media-folder plugin


### PR DESCRIPTION
- Active le plugin `epfl-menu` lors des déploiements Gutenberg
- Supprime le plugin `epfl` de l'image.

**NOTE**
- Merger d'abord https://github.com/epfl-idevelop/jahia2wp/pull/1099 et suivre doc dans la PR 1099