### PR TITLE
Allow TinyMCE for all

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -106,7 +106,7 @@
 - name: '"TinyMCE Advanced" plugin'
   wordpress_plugin:
     name: tinymce-advanced
-    state: 
+    state:
       - symlinked
       - active
     from: wordpress.org/plugins

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -106,7 +106,9 @@
 - name: '"TinyMCE Advanced" plugin'
   wordpress_plugin:
     name: tinymce-advanced
-    state: symlinked
+    state: 
+      - symlinked
+      - active
     from: wordpress.org/plugins
 
 - name: Polylang plugin

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -106,10 +106,7 @@
 - name: '"TinyMCE Advanced" plugin'
   wordpress_plugin:
     name: tinymce-advanced
-    state:
-      - symlinked
-      - >-
-        {{ "inactive" if plugins_use_gutenberg else "active" }}
+    state: symlinked
     from: wordpress.org/plugins
 
 - name: Polylang plugin


### PR DESCRIPTION
Réactivation du plugin TinyMCE Avanced pour tous (en lien avec https://github.com/epfl-idevelop/jahia2wp/pull/1107)