### PR TITLE
Add PDF Block plugin

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -111,6 +111,14 @@
       - active
     from: wordpress.org/plugins
 
+- name: Gutenberg PDF Viewer Block
+  wordpress_plugin:
+    name: pdf-viewer-block
+    state:
+      - symlinked
+      - active
+    from: wordpress.org/plugins
+
 - name: Polylang plugin
   wordpress_plugin:
     name: polylang


### PR DESCRIPTION
Ajout du plugin PDF Viewer en mode bloc dans l'image.
Lié à la PR https://github.com/epfl-idevelop/jahia2wp/pull/1111