### PR TITLE
Remove old shortcode plugin from image

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -311,14 +311,6 @@
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_wpmf_options }}"
 
-# TODO: We are not sure what is up with WP5 and this one.
-- name: pdfjs-viewer-shortcode plugin
-  wordpress_plugin:
-    name: pdfjs-viewer-shortcode
-    state:
-      - symlinked
-    from: wordpress.org/plugins
-
 - name: very-simple-meta-description plugin
   wordpress_plugin:
     name: very-simple-meta-description


### PR DESCRIPTION
Après l'installation du plugin "bloc" pour afficher un PDF (https://github.com/epfl-idevelop/jahia2wp/pull/1111) et la transformation des pages pour utiliser celui-ci, on peut supprimer l'ancien, celui sous forme de shortcode.
