### PR TITLE
Adapt for MU-Plugin epfl-custom-editor-menu which now has a loader

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -31,7 +31,9 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+    from: 
+      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-custom-editor-menu
+      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu_loader.php
 
 
 - name: Blocks white-list (must-use plugin)


### PR DESCRIPTION
Adaptations pour le plugin "EPFL Custom editor menu" pour faire en sorte d'inclure le loader et le dossier à l'image. En lien avec la PR https://github.com/epfl-idevelop/jahia2wp/pull/1121