### PR TITLE
[fix] One tinymce-advanced version per WordPress version

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -125,12 +125,12 @@ RUN set -e -x; for wp in /wp/*; do                                         \
   cd $wp;                                                                  \
   wpmajorminor="$(basename $wp | cut -d. -f1-2)";                          \
   case "$wpmajorminor" in 4.*) wpmajorminor="4.8" ;; esac ;                \
-  rm -rf wp-content/plugins/tinymce-advanced;                              \
   curl -q https://api.wordpress.org/plugins/info/1.0/tinymce-advanced.json \
   | jq -r ".versions | to_entries                                          \
          | map(select (.key | startswith(\"$wpmajorminor\")))              \
          | map(.value) | last"                                             \
      | xargs -t -i curl -o tinymce-advanced.zip {} ;                       \
+  rm -rf wp-content/plugins/tinymce-advanced;                              \
   (cd wp-content/plugins; unzip ../../tinymce-advanced.zip);               \
   rm tinymce-advanced.zip;                                                 \
   done

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -119,6 +119,22 @@ RUN set -e -x; for wp in /wp/*; do cd $wp ;                              \
         /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS};   \
     done
 
+# Special treatment for tinymce-advanced, whose version scheme follows
+# WordPress' starting at 5.2
+RUN set -e -x; for wp in /wp/*; do                                         \
+  cd $wp;                                                                  \
+  wpmajorminor="$(basename $wp | cut -d. -f1-2)";                          \
+  case "$wpmajorminor" in 4.*) wpmajorminor="4.8" ;; esac ;                \
+  rm -rf wp-content/plugins/tinymce-advanced;                              \
+  curl -q https://api.wordpress.org/plugins/info/1.0/tinymce-advanced.json \
+  | jq -r ".versions | to_entries                                          \
+         | map(select (.key | startswith(\"$wpmajorminor\")))              \
+         | map(.value) | last"                                             \
+     | xargs -t -i curl -o tinymce-advanced.zip {} ;                       \
+  (cd wp-content/plugins; unzip ../../tinymce-advanced.zip);               \
+  rm tinymce-advanced.zip;                                                 \
+  done
+
 # Manually add the wordpress-importer plugin, used in "ventilation"
 # operations. Patch it to nuke the stat() cache inbetween downloading
 # things

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -124,10 +124,13 @@ RUN set -e -x; for wp in /wp/*; do cd $wp ;                              \
 RUN set -e -x; for wp in /wp/*; do                                         \
   cd $wp;                                                                  \
   wpmajorminor="$(basename $wp | cut -d. -f1-2)";                          \
-  case "$wpmajorminor" in 4.*) wpmajorminor="4.8" ;; esac ;                \
+  case "$wpmajorminor" in                                                  \
+      4.*) tinymcemajorminor="4.8" ;;                                      \
+      *)   tinymcemajorminor="$wpmajorminor" ;;                            \
+  esac ;                                                                   \
   curl -q https://api.wordpress.org/plugins/info/1.0/tinymce-advanced.json \
   | jq -r ".versions | to_entries                                          \
-         | map(select (.key | startswith(\"$wpmajorminor\")))              \
+         | map(select (.key | startswith(\"$tinymcemajorminor\")))         \
          | map(.value) | last"                                             \
      | xargs -t -i curl -o tinymce-advanced.zip {} ;                       \
   rm -rf wp-content/plugins/tinymce-advanced;                              \


### PR DESCRIPTION
Recently we discovered that newly-installed sites complain about `tinymce-advanced` plugin being too recent w.r.t. the WordPress version (e.g. `tinymce-advanced` version 5.3.0 for WordPress 5.2.1). Fix that.

- Examine WordPress repository through its API to find out and use the most recent version of `tinymce-advanced` per WordPress version lineage:
    - 4.8 for WordPress 4.9
    - 5.`x` for WordPress 5.`x`, for known values of `x` so far (2 and soon, 3)
- Create a wart in the Dockerfile to remove and reinstall `tinymce-advanced` plugin according to these findings
