### PR TITLE
Fixes to Ansible plugin and mu-plugin management

### DIFF
--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -30,6 +30,7 @@ _symlinks_muplugins_always:
   - EPFL_jahia_redirect.php
   - EPFL_quota_loader.php
   - EPFL_stats_loader.php
+  - EPFL_google_analytics_hook.php
   - epfl-functions.php
   - epfl-quota
   - epfl-stats


### PR DESCRIPTION
Fix 1: when a plugin or mu-plugin symlink was done "the old way" (e.g. to `/wp/wp-content`), which is now incorrect (as it pins the version of a particular plugin back in time), Ansible currently doesn't detect and fix it.

- Introduce a new state in `get_current_state()`, `symlink_damaged`
- It turns out that said `get_current_state()` was incorrectly assuming that everything is a plugin (not a must-use plugin); fix that

Fix 2: (more like a stop-gap) Install `EPFL_google_analytics_hook.php` everywhere