### PR TITLE
Manage mu-plugins and plugins consisting of more than one file — The Right Way™

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -135,8 +135,7 @@ class ActionModule(ActionBase):
         elif len(installation_state) == 1:
             return list(installation_state)[0]
         else:
-            raise ValueError('Plug-in %s cannot be simultaneously %s' % (
-                name, list(installation_state)))
+            raise ValueError('Plug-in cannot be simultaneously %s' % str(list(installation_state)))
 
     def _desired_activation_state(self, desired_state):
         activation_state = desired_state.intersection(['active', 'inactive', 'must-use'])
@@ -145,8 +144,7 @@ class ActionModule(ActionBase):
         elif len(activation_state) == 1:
             return list(activation_state)[0]
         else:
-            raise ValueError('Plug-in %s cannot be simultaneously %s' %
-                             (name, list(activation_state)))
+            raise ValueError('Plug-in %s cannot be simultaneously %s' % str(list(activation_state)))
 
     def _do_symlink_file (self, basename, is_mu):
         return self._run_action('file', {

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -18,6 +18,9 @@ class ActionModule(ActionBase):
 
         name = args.get('name')
 
+        # desired_state is common to all files
+        desired_state = self._get_desired_state(name, args)
+
         # TODO: this assumes that there is always only one file, whose name
         # is the name of the plug-in. This is not the case typically for
         # mu-plugins.
@@ -26,7 +29,6 @@ class ActionModule(ActionBase):
             self._get_plugin_activation_state(name)
         ])
 
-        desired_state = self._get_desired_state(name, args)
         to_do = desired_state - current_state
         to_undo = current_state - desired_state
         cares_about_installation_state = bool(self._desired_installation_state(desired_state))
@@ -125,12 +127,6 @@ class ActionModule(ActionBase):
                              (name, activation_state))
 
         return desired_state
-
-    def _do_uninstall_plugin (self, name):
-        result = self._run_wp_cli_action('plugin deactivate %s' % name)
-        if 'failed' not in result:
-            result.update(self._do_rimraf_plugin(name))
-        return result
 
     def _desired_installation_state(self, desired_state):
         installation_state = desired_state.intersection(['present', 'absent', 'symlinked'])

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -77,8 +77,7 @@ class ActionModule(ActionBase):
         paths = (self._get_plugin_path(basename),
                      self._get_muplugin_path(basename))
         for path in paths:
-            plugin_stat = self._run_action('stat', { 'path': path },
-                                           record_errors=False)
+            plugin_stat = self._run_action('stat', { 'path': path })
             if 'failed' in plugin_stat:
                 raise AnsibleActionFail("Cannot stat() %s" % path)
             file_exists = ('stat' in plugin_stat and plugin_stat['stat']['exists'])
@@ -179,17 +178,14 @@ class ActionModule(ActionBase):
     def _run_shell_action (self, cmd):
         return self._run_action('command', { '_raw_params': cmd, '_uses_shell': True })
 
-    def _run_action (self, action_name, args, record_errors=True):
+    def _run_action (self, action_name, args):
         # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins
         # at § “Action Plugins”
         result = self._execute_module(module_name=action_name,
                                       module_args=args, tmp=self._tmp,
                                       task_vars=self._task_vars)
-        if record_errors:
-            self._update_result(result)
-            return self.result
-        else:
-            return result
+        self._update_result(result)
+        return self.result
 
     def _get_wp_dir (self):
         return self._get_ansible_var('wp_dir')

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -18,8 +18,6 @@ class ActionModule(ActionBase):
         args = self._task.args
 
         name = args.get('name')
-        if name == 'EPFL_stats_loader':
-            import sys; sys.path.append("/Users/quatrava/Library/Application Support/IntelliJIdea2019.2/python/pydevd-pycharm.egg"); import pydevd; pydevd.settrace('localhost', port=12477, stdoutToServer=True, stderrToServer=True)
 
         current_state = set([self._get_plugin_activation_state(name)])
         desired_state = self._get_desired_state(name, args)
@@ -80,7 +78,7 @@ class ActionModule(ActionBase):
             raise NotImplementedError('Installing "regular" (non-symlinked) plugin %s '
                                       'not supported (yet)' % basename)
 
-        if  'symlinked' in to_undo or 'installed' in to_undo:
+        if 'symlinked' in to_undo or 'installed' in to_undo:
             self._update_result(self._do_rimraf_file(basename, is_mu))
             if 'failed' in self.result: return self.result
 
@@ -227,5 +225,5 @@ class ActionModule(ActionBase):
                 self.result[flag_name] = oldresult[flag_name]
 
         _keep_flag('changed')
-                
+
         return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -18,6 +18,8 @@ class ActionModule(ActionBase):
         args = self._task.args
 
         name = args.get('name')
+        if name == 'EPFL_stats_loader':
+            import sys; sys.path.append("/Users/quatrava/Library/Application Support/IntelliJIdea2019.2/python/pydevd-pycharm.egg"); import pydevd; pydevd.settrace('localhost', port=12477, stdoutToServer=True, stderrToServer=True)
 
         current_state = set([self._get_plugin_activation_state(name)])
         desired_state = self._get_desired_state(name, args)
@@ -68,8 +70,8 @@ class ActionModule(ActionBase):
 
     def _ensure_file_state (self, desired_state, basename, is_mu):
         current_state = set([self._get_current_file_state(basename, is_mu)])
-        to_do = set(desired_state) - current_state
-        to_undo = current_state - set(desired_state)
+        to_do = set([desired_state]) - current_state
+        to_undo = current_state - set([desired_state])
 
         if not (to_do or to_undo):
             return

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -71,9 +71,7 @@
 - name: Locked installs (must-use plugin)
   wordpress_plugin:
     name: EPFL_installs_locked
-    state:
-      - symlinked
-      - must-use
+    state: '{{ ["symlinked", "must-use" if wp_is_managed else "absent" ] }}'
     from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
 
 - name: Jahia redirect tracker (must-use plugin)

--- a/ansible/roles/wordpress-instance/vars/symlink-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/symlink-vars.yml
@@ -22,45 +22,7 @@ symlinks_themes:
   - wp-theme-2018
   - wp-theme-light
 
-_symlinks_muplugins_always:
-  - epfl-custom-editor-menu
-  - EPFL_custom_editor_menu_loader.php
-  - EPFL_disable_comments.php
-  - EPFL_disable_updates_automatic.php
-  - EPFL_jahia_redirect.php
-  - EPFL_quota_loader.php
-  - EPFL_stats_loader.php
-  - EPFL_google_analytics_hook.php
-  - epfl-functions.php
-  - epfl-quota
-  - epfl-stats
-
-_symlinks_muplugins_managed:
-  - EPFL_installs_locked.php
-
-_symlinks_muplugins_by_group:
-  prod-inside:
-    - EPFL_google_analytics_hook.php
-  prod-labs:
-    - EPFL_google_analytics_hook.php
-  prod-www:
-    - EPFL_google_analytics_hook.php
-
-_symlinks_muplugins_yaml: |
-  {{ _symlinks_muplugins_always | to_nice_yaml }}
-  {% if wp_is_managed %}{#    From category-vars.yml  #}
-  {{ _symlinks_muplugins_managed | to_nice_yaml }}
-  {% endif %}
-  {% for group, moar_muplugins in _symlinks_muplugins_by_group.items() %}
-  {%   if group_names | intersect(["prod-inside"]) %}
-  {{     moar_muplugins | to_nice_yaml }}
-  {%   endif %}
-  {% endfor %}
-
-symlinks_muplugins: "{{ _symlinks_muplugins_yaml | from_yaml }}"
-
 symlinks_managed_in_bulk: >
   {{ symlinks_paths_wp
-    + ('wp-content/mu-plugins/%s' | map_format(symlinks_muplugins))
     + ('wp-content/themes/%s'     | map_format(symlinks_themes))
   }}


### PR DESCRIPTION
- Refactor `ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py` to deal with a multiplicity of files
- (Almost) stop mixing up install- and activation-related states (still do so on the “expected” side)
- We are now able to symlink a mu-plugin that was not already there, and do so in a smart way (i.e. computed from a Jinja template)