### PR TITLE
[WAIT] Add cortneray Polylang WPCLI package with patch

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -65,6 +65,7 @@ RUN chmod 755 /usr/local/bin/wp
 
 # Add Polylang-related extension packages to wp-cli
 COPY ./config.yml /var/www/.wp-cli/config.yml
+COPY ./cortneyray/* /tmp/cortneyray/
 RUN mkdir /var/www/.composer; \
     chown -R www-data:www-data /var/www/.wp-cli /var/www/.composer
 RUN su -s /bin/sh www-data -c " \
@@ -73,9 +74,10 @@ RUN su -s /bin/sh www-data -c " \
         composer config -g github-oauth.github.com '${GITHUB_API_TOKEN}'; \
     fi;                                                                   \
     wp package install https://github.com/diggy/polylang-cli.git ;        \
-    wp package install https://github.com/cortneyray/wp-cli-polylang.git; \
+    wp package install /tmp/cortneyray/; \
     wp package install https://github.com/epfl-idevelop/wp-cli.git;       \
     rm -f ~/.composer/auth.json"
+
 
 ######################################################################
 # Install and patch WordPresses

--- a/docker/wp-base/cortneyray/wp-cli-polylang/PolylangHelperFunctions.php
+++ b/docker/wp-base/cortneyray/wp-cli-polylang/PolylangHelperFunctions.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Polylang for WP-CLI
+ *
+ * Helper global functions
+ *
+ * This is a temporary file, pending integration to Polylang API (api.php).
+ * As this API uses global functions starting with pll_, we follow the convention.
+ *
+ * @package     WP-CLI
+ * @subpackage  Polylang
+ * @filesource
+ */
+
+/**
+ * @return bool
+ */
+function pll_installed_language_list()
+{
+    global $polylang;
+
+    return isset($polylang) ? $polylang->model->get_languages_list() : false;
+}
+
+/**
+ * @param $languageCode
+ * @return array|null
+ */
+function pll_get_default_language_information($languageCode)
+{
+    global $polylang;
+
+    /* Depending Polylang version, 'languages.php' initializes $languages var or returns an array with all of 
+     the languages content. This array has languageCode as key so it's easier to find a language */
+    $req_res = (require PLL_SETTINGS_INC.'/languages.php' );
+    if(is_array($req_res)) $languages = $req_res;
+
+    if(array_key_exists($languageCode, $languages))
+    {
+        return array(
+            'code'      => $languages[$languageCode]['code'],
+            'locale'    => $languages[$languageCode]['locale'],
+            'name'      => $languages[$languageCode]['name'],
+            'rtl'       => $languages[$languageCode]['dir'],
+            'flag'      => $languages[$languageCode]['flag']
+        );
+    }
+
+    return null;
+}
+
+/**
+ * @param $languageCode
+ * @return bool
+ */
+function pll_is_valid_language_code($languageCode)
+{
+    return pll_get_default_language_information($languageCode) !== null;
+}
+
+/**
+ * @param $languageCode
+ * @param int $languageOrder
+ * @return mixed
+ */
+function pll_add_language($languageCode, $languageOrder = 0)
+{
+    global $polylang;
+
+    $info = pll_get_default_language_information($languageCode);
+
+    $args = array(
+        'name'        => $info['name'],
+        'slug'        => $info['code'],
+        'locale'      => $info['locale'],
+        'flag'        => $info['flag'],
+        'rtl'         => ($info['rtl'] == 'rtl') ? 1 : 0,
+        'term_group'  => $languageOrder
+    );
+
+    return $polylang->model->add_language($args);
+}
+
+/**
+ * @param $languageCode
+ * @return bool
+ */
+function pll_del_language($languageCode)
+{
+    global $polylang;
+
+    $languages = pll_installed_language_list();
+
+    if (!$languages) {
+        return false;
+    }
+
+    foreach ($languages as $language) {
+        if ($language->slug == $languageCode || $language->locale == $languageCode) {
+            $polylang->model->delete_language((int)$language->term_id);
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @param $languageCode
+ * @return bool
+ */
+function pll_is_language_installed($languageCode)
+{
+    $languages = pll_installed_language_list();
+
+    if (!$languages) {
+        return false;
+    }
+
+    foreach ($languages as $language) {
+        if ($language->slug == $languageCode || $language->locale == $languageCode) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @param $type
+ * @param $slug
+ * @return mixed
+ */
+function pll_get_id_by_slug($type, $slug)
+{
+    switch ($type) {
+        case 'post':
+
+            $query = new WP_Query(['pagename' => $slug, 'post_type' => ['post', 'page', 'event']]);
+            $posts = $query->get_posts();
+            if (!empty($posts)) {
+                return $posts[0]->ID;
+            }
+
+            break;
+        case 'term':
+
+            $term = get_term_by('slug', $slug, 'category');
+            if ($term) {
+                return (int)$term->term_id;
+            }
+
+            break;
+        default:
+            break;
+    }
+
+    return $slug;
+}

--- a/docker/wp-base/cortneyray/wp-cli-polylang/Polylang_Command.php
+++ b/docker/wp-base/cortneyray/wp-cli-polylang/Polylang_Command.php
@@ -1,0 +1,394 @@
+<?php
+/**
+ * Polylang for WP-CLI
+ *
+ * Polylang_Command class wp polylang
+ *
+ * @package     WP-CLI
+ * @subpackage  Polylang
+ * @filesource
+ */
+if (!defined('WP_CLI')) {
+    return;
+}
+
+define('PLL_ADMIN', true);
+define('PLL_SETTINGS', true);
+require_once 'PolylangHelperFunctions.php';
+
+/**
+ * Class Polylang_Command
+ */
+class Polylang_Command extends WP_CLI_Command
+{
+    /**
+     * Shows available languages
+     *
+     * ## EXAMPLES
+     *     wp polylang languages
+     *
+     * @synopsis
+     */
+    function languages($args, $assocArgs)
+    {
+        $languages = pll_installed_language_list();
+        if (!$languages) {
+            WP_CLI::success("No languages are currently configured.");
+
+            return;
+        }
+        $default = pll_default_language();
+        foreach ($languages as $language) {
+            $line = "$language->slug — $language->name";
+            if ($language->slug == $default) {
+                $line .= ' [DEFAULT]';
+            }
+            WP_CLI::line($line);
+        }
+    }
+
+    /**
+     * Show home URL of specified language
+     *
+     * ## OPTIONS
+     * <language-code>
+     * : The language to get the home URL to.
+     *
+     * ## EXAMPLES
+     *   wp polylang home
+     *   wp polylang home fr
+     *
+     * @synopsis [<language-code>]
+     */
+    function home($args, $assocArgs)
+    {
+        $lang = (count($args) == 1) ? $args[0] : '';
+        $url = pll_home_url($lang);
+        WP_CLI::line($url);
+    }
+
+    /**
+     * Shows post or term in specified language
+     *
+     * ## OPTIONS
+     * <data-type>
+     * : 'post' or 'term'
+     *
+     * <data-id>
+     * : the ID/slug of the object to get
+     *
+     * <language-count>
+     * : the language (if omitted, will be returned in the default language)
+     *
+     * ## EXAMPLES
+     *   wp polylang get post 1 fr
+     *
+     * @synopsis <data-type> <data-id> [<language-code>]
+     */
+    function get($args, $assocArgs)
+    {
+        $lang = (count($args) == 2) ? '' : $args[2];
+        switch ($what = $args[0]) {
+            case 'post':
+            case 'term':
+                $method = 'pll_get_'.$what;
+                break;
+            default:
+                WP_CLI::error("Expected: wp polylang get <post or term> ..., not '$what'");
+        }
+        $ptId = pll_get_id_by_slug($what, $args[1]);
+
+        $id = $method($ptId, $lang);
+        WP_CLI::line($id);
+    }
+
+    /**
+     * Shows language of post or term as slug
+     *
+     * ## OPTIONS
+     * <data-type>
+     * : 'post' or 'term'
+     *
+     * <data-id>
+     * : the ID of the object to get the language for
+     *
+     * ## EXAMPLES
+     *   wp polylang getlang post 12
+     *   wp polylang getlang term 5
+     *
+     * @synopsis <data-type> <data-id>
+     */
+    function getlang($args, $assocArgs)
+    {
+        switch ($what = $args[0]) {
+            case 'post':
+            case 'term':
+                $method = 'pll_get_'.$what.'_language';
+                break;
+            default:
+                WP_CLI::error("Expected: wp polylang getlang <post or term> ..., not '$what'");
+        }
+
+        if (!function_exists($method)) {
+            WP_CLI::error("function $method does not exist befor polylang 1.5.4!");
+        }
+
+        $lang = $method($args[1]);
+        if (!$lang) {
+            WP_CLI::error("'$what' $args[1] is not managed yet");
+        }
+
+        WP_CLI::line($lang);
+    }
+
+    /**
+     * Sets language of post or term
+     *
+     * ## OPTIONS
+     * <data-type>
+     * : 'post' or 'term'
+     *
+     * <data-id>
+     * : the ID/slug of the object to set
+     *
+     * <language-code>
+     * : the language (if omitted, will be set to the default language)
+     *
+     * ## EXAMPLES
+     *   wp polylang set post 1 fr
+     *
+     * @synopsis <data-type> <data-id> [<language-code>]
+     */
+    function set($args, $assocArgs)
+    {
+        $lang = '';
+        // is no language code given - use default
+        if (count($args) == 2) {
+            $lang = pll_default_language();
+        } // use the lang code given - test if the lang is installed
+        else {
+            $lang = $args[2];
+            if (!pll_is_language_installed($lang)) {
+                WP_CLI::error("Language '$lang' is not installed!");
+            }
+        }
+        switch ($what = $args[0]) {
+            case 'post':
+            case 'term':
+                $method = 'pll_set_'.$what.'_language';
+                break;
+            default:
+                WP_CLI::error("Expected: wp polylang set <post or term> ..., not '$what'");
+        }
+        $ptId = pll_get_id_by_slug($what, $args[1]);
+
+        $method($ptId, $lang);
+        WP_CLI::success("language for $what $args[1] saved");
+    }
+
+    /**
+     * Associate terms or post as translations
+     *
+     * ## OPTIONS
+     * <data-type>
+     * : 'post' or 'term'
+     *
+     * <data-ids>
+     * : comma separated list of data IDs that are translations of each other
+     *
+     * ## EXAMPLES
+     *   wp polylang trans post 1,7,9
+     *   wp polylang trans term 27,32
+     *
+     * @synopsis <data-type> <data-ids>
+     */
+    function trans($args, $assocArgs)
+    {
+        // comma sperated list as array
+        $data_ids = explode(',', $args[1]);
+        // two or more ids necessary
+        if (count($data_ids) < 2) {
+            WP_CLI::error("need at least two ids for translation");
+        }
+        // term or post
+        switch ($what = $args[0]) {
+            case 'post':
+            case 'term':
+                $method = 'pll_save_'.$what.'_translations';
+                $get_lang_method = 'pll_get_'.$what.'_language';
+                break;
+            default:
+                WP_CLI::error("Expected: wp polylang trans <post or term> ..., not '$what'");
+        }
+        // only available since 1.5.4 of polylang
+        if (!function_exists($get_lang_method)) {
+            WP_CLI::error("function $get_lang_method does not exist befor polylang 1.5.4 and is necessary for this implementation!");
+        }
+        // get language of each term or post and build array for the pll_save api function
+        $arr = array();
+        foreach ($data_ids as $id) {
+
+            $ptId = pll_get_id_by_slug($what, $id);
+
+            $lang = $get_lang_method($ptId);
+            // is the post or term already managed
+            if (!$lang) {
+                WP_CLI::error("'$what' $ptId is not managed yet and cannot be translated");
+            }
+            // is there a post or term with the same language given?
+            if (array_key_exists($lang, $arr)) {
+                WP_CLI::error("$lang => $ptId as well as $lang => $arr[$lang] ar two $what with the same language!");
+            }
+            $arr[$lang] = intval($ptId);
+        }
+        // save the translation
+        $method($arr);
+        WP_CLI::success("translations saved");
+    }
+
+    /**
+     * Add, show or remove available language
+     *
+     * ## OPTIONS
+     * <operation>
+     * : the language operation (add, info, del)
+     *
+     * <language-code>
+     * : the language code
+     *
+     * <order>
+     * : for add operation, indicates the order of the language
+     *
+     * ## EXAMPLES
+     *   wp polylang language add fr
+     *   wp polylang language add nl 2
+     *   wp polylang language info vec
+     *   wp polylang language del vec
+     *
+     * @synopsis <operation> <language-code> [<order>]
+     */
+    function language($args, $assocArgs)
+    {
+        $language_code = $args[1];
+        $language_order = (count($args) == 3) ? $args[2] : 0;
+        $language_info = pll_get_default_language_information($language_code);
+        if ($language_info === null) {
+            WP_CLI::error("$language_code isn't a valid language code.");
+
+            return;
+        }
+        $language_installed = pll_is_language_installed($language_code);
+        switch ($args[0]) {
+            case 'info':
+                WP_CLI::line('Code:      '.$language_info['code']);
+                WP_CLI::line('Locale     '.$language_info['locale']);
+                WP_CLI::line('Name:      '.$language_info['name']);
+                WP_CLI::line('RTL:       '.($language_info['rtl'] ? 'yes' : 'no'));
+                WP_CLI::line('Installed: '.($language_installed ? 'yes' : 'no'));
+                break;
+            case 'add':
+                if ($language_installed) {
+                    WP_CLI::warning("This language is already installed.");
+
+                    return;
+                }
+                if (pll_add_language($language_code, $language_order)) {
+                    WP_CLI::success("Language added.");
+
+                    return;
+                }
+                WP_CLI::error("Can't add the language.");
+                break;
+            case 'del':
+                if (!$language_installed) {
+                    WP_CLI::warning("This language isn't installed.");
+
+                    return;
+                }
+                if (pll_del_language($language_code)) {
+                    WP_CLI::success("Language deleted.");
+
+                    return;
+                }
+                WP_CLI::error("Could not delete language");
+                break;
+            default:
+                WP_CLI::error("Unknown command: polylang language $args[0]. Expected: add/del/info.");
+        }
+    }
+
+    /**
+     * Add language switcher to menu
+     *
+     * ## OPTIONS
+     * <menu_id>
+     * : the menu id, name or slug
+     *
+     * [--hide_if_no_translation=<boolean>]
+     * : hide the switcher, if no translation (for post/page) is available
+     * : Accepted values: 0, 1. Default: 0
+     *
+     * [--hide_current=<boolean>]
+     * : hide the current language
+     * : Accepted values: 0, 1. Default: 0
+     *
+     * [--force_home=<boolean>]
+     * : link to home (instead of translated post/page)
+     * : Accepted values: 0, 1. Default: 0
+     *
+     * [--show_flags=<boolean>]
+     * : show language flags
+     * : Accepted values: 0, 1. Default: 0
+     *
+     * [--show_names=<boolean>]
+     * : show language names
+     * : Accepted values: 0, 1. Default: 1
+     *
+     * ## EXAMPLES
+     *   wp polylang langswitcher 1
+     *
+     * @synopsis <menu_id> [--hide_if_no_translation=<boolean>] [--hide_current=<boolean>] [--force_home=<boolean>] [--show_flags=<boolean>] [--show_names=<boolean>]
+     */
+    function langswitcher($args, $assocArgs)
+    {
+        $menu_id = $args[0];
+        // check if the menu exists
+        $nav_menu = wp_get_nav_menu_object($args[0]);
+        if (false === $nav_menu) {
+            WP_CLI::error("Invalid menu ".$menu_id);
+        }
+        // handle options
+        $options = wp_parse_args($assocArgs, array(
+            'hide_if_no_translation' => 0,
+            'hide_current' => 0,
+            'force_home' => 0,
+            'show_flags' => 0,
+            'show_names' => 1
+        ));
+        // at least one needs to be activated - otherwise use default
+        if (!$options['show_flags'] && !$options['show_names']) {
+            $options['show_names'] = 1;
+        }
+        // add the language switcher as new menu item
+        $menu_item_db_id = wp_update_nav_menu_item($nav_menu->term_id, 0, array(
+            'menu-item-title' => __('Language switcher', 'polylang'),
+            'menu-item-url' => '#pll_switcher',
+            'menu-item-status' => 'publish'
+        ));
+        // check for success
+        if (is_wp_error($menu_item_db_id)) {
+            WP_CLI::error("could not add language switcher: ".$menu_item_db_id->get_error_message());
+        }
+        // update the meta data, so that the Language switcher really behaves the desired way
+        if (!update_post_meta($menu_item_db_id, '_pll_menu_item', $options)) {
+            // cleanup
+            wp_delete_post($menu_item_db_id);
+            WP_CLI::error("error setting options for Language Switcher menu item");
+        }
+        // success
+        WP_CLI::success("Added language switcher with db_id: ".$menu_item_db_id);
+    }
+}
+
+WP_CLI::add_command('polylang', 'Polylang_Command');
+WP_CLI::add_command('pll', 'Polylang_Command'); //alias for the users expecting to use the API shortname.

--- a/docker/wp-base/cortneyray/wp-cli-polylang/README.md
+++ b/docker/wp-base/cortneyray/wp-cli-polylang/README.md
@@ -1,0 +1,30 @@
+wp-cli-polylang
+===============
+  
+WP-CLI community package to support Polylang WordPress plug-in.
+  
+Command added
+-------------
+
+**NAME**
+  
+    wp polylang
+  
+**DESCRIPTION**
+  
+    Implements polylang command, to interact with the Polylang plug-in.
+  
+**SYNOPSIS**
+  
+    wp polylang <command>
+  
+**SUBCOMMANDS**
+  
+    get            Gets a post or a term in the specified language
+    home           Gets the site homepage URL in the specified language
+    language       Adds, gets information or remove a language
+    languages      Prints the languages currently available
+    getlang        Get the language of a post or a term as slug
+    set            Sets a post or a term to the specified language
+    trans          Associate terms or post as translations
+    langswitcher   add the language switcher to a menu

--- a/docker/wp-base/cortneyray/wp-cli-polylang/composer.json
+++ b/docker/wp-base/cortneyray/wp-cli-polylang/composer.json
@@ -1,0 +1,34 @@
+{
+	"name" : "cortneyray/wp-cli-polylang",
+	"type" : "command",
+	"description" : "Add wp polylang command to support Polylang plug-in",
+	"keywords" : [
+		"wp-cli",
+		"polylang",
+		"i18n"
+	],
+	"homepage" : "https://github.com/cortneyray/wp-cli-polylang",
+	"license" : "GPLv2",
+	"authors" : [{
+			"name" : "F.A. Fiebig",
+			"email" : "",
+			"homepage" : "http://exozet.com",
+			"role" : "Sen. Developer"
+		}
+	],
+	"require" : {
+		"php" : ">=5.3.0"
+	},
+	"autoload" : {
+		"files" : [
+			"PolylangHelperFunctions.php",
+			"Polylang_Command.php"
+		]
+	},
+	"repositories" : [{
+			"type" : "git",
+			"url" : "https://github.com/cortneyray/wp-cli-polylang",
+			"name" : "cortneyray/wp-cli-polylang"
+		}
+	]
+}


### PR DESCRIPTION
Investigation pour savoir pourquoi la commande `wp polylang language add` qui vient du package WPCLI `cortneray/wp-cli-polylang` ne fonctionnait plus pour les versions Polylang > 2.2.8.
Adaptation du code pour corriger la chose et supporter les versions de Polylang:
- plus grand que 2.2.8 et jusqu'à 2.5.x 
Passage d'un tableau non associatif (dans `settings/languages.php`) à un tableau associatif pour lister les langages disponibles, )c'est ça qui faisait péter nos installations avec `jahia2wp.py`) 
- à partir de 2.6.x 
Le tableau associatif est maintenant "retourné" et plus initialisé (dans `settings/languages.php`)

Selon discussion avec @lvenries , une PR a été faite sur le repo officiel du package (https://github.com/cortneyray/wp-cli-polylang/pull/1) mais au vu du peu d'activité dessus, il a été choisi d'inclure "temporairement" le code du package au sein de `wp-ops`. Il pourra être enlevé le jour où la PR aura été mergée.