### PR TITLE
Check out the epfl-menus plugin from its new home

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -303,7 +303,7 @@
     name: epfl-menus
     state: >-
         {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-menus
+    from: https://github.com/epfl-idevelop/wp-plugin-epfl-menus
 
 - name: wp-media-folder plugin
   wordpress_plugin:


### PR DESCRIPTION
Said plugin was extracted out of jahia2wp using the following script:

```
git clone ~/Dev/WordPress/volumes/wp/jahia2wp epfl-menus
cd epfl-menus
git checkout origin/release2018
git checkout -b release2018

git filter-repo --path data/wp/wp-content/plugins/epfl-menus \
  --path-rename 'data/wp/wp-content/plugins/epfl-menus/epfl-menus-admin.css:epfl-menus-admin.css' \
  --path-rename 'data/wp/wp-content/plugins/epfl-menus/epfl-menus-admin.js:epfl-menus-admin.js' \
  --path-rename 'data/wp/wp-content/plugins/epfl-menus/epfl-menus.php:epfl-menus.php' \
  --path-rename 'data/wp/wp-content/plugins/epfl-menus/wpcli.php:wpcli.php' \
  --path-rename 'data/wp/wp-content/plugins/epfl-menus/lib:lib' \
  --force

git checkout -B master
git remote add origin git@github.com:epfl-idevelop/wp-plugin-epfl-menus.git
git push
```