### PR TITLE
[fix] Portability warts in new Python inventory scripts

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -3,7 +3,7 @@
 import sys
 import os
 # To be able to include package wp_inventory in parent directory
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 
 from wp_inventory import WPInventory
 import json

--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -1,8 +1,9 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
+import os
 # To be able to include package wp_inventory in parent directory
-sys.path.append("..")
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from wp_inventory import WPInventory
 import json

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -3,7 +3,7 @@
 import sys
 import os
 # To be able to include package wp_inventory in parent directory
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir))
 
 from wp_inventory import WPInventory
 import json

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -1,8 +1,9 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
+import os
 # To be able to include package wp_inventory in parent directory
-sys.path.append("..")
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from wp_inventory import WPInventory
 import json


### PR DESCRIPTION
- Work out the argument to `sys.path.append` in a way that doesn't
depend on which directory is current

- Use a `#!/usr/bin/env` shebang, for people who don't have a
`/usr/bin/python3` (e.g., Mac OS X) or don't want to use it (e.g.,
`virtualenv`)