### PR TITLE
Install Ansible into the mgmt image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,16 @@ script:
   set -e -x
   docker pull ubuntu:bionic
 
-  branch_build_arg=
+  wp_base_branch_build_arg=
+  other_dockers_build_args=
   if [ -n "$TRAVIS_BRANCH" ]; then
-    branch_build_arg="--manifest-url=https://raw.githubusercontent.com/epfl-idevelop/wp-ops/$TRAVIS_BRANCH/ansible/roles/wordpress-instance/tasks/plugins.yml"
+    wp_base_branch_build_arg="--manifest-url=https://raw.githubusercontent.com/epfl-idevelop/wp-ops/$TRAVIS_BRANCH/ansible/roles/wordpress-instance/tasks/plugins.yml"
+    other_dockers_build_args="--build-arg WP_OPS_BRANCH=$TRAVIS_BRANCH"
   fi
   docker build \
      --build-arg "GITHUB_API_USER=${GITHUB_API_USER}"           \
      --build-arg "GITHUB_API_TOKEN=${GITHUB_API_TOKEN}"         \
-     --build-arg "INSTALL_AUTO_FLAGS=--exclude=wp-media-folder $branch_build_arg" \
+     --build-arg "INSTALL_AUTO_FLAGS=--exclude=wp-media-folder $wp_base_branch_build_arg" \
      -t epflidevelop/os-wp-base docker/wp-base
   find docker -mindepth 1 -maxdepth 1 -type d \
-    | grep -v wp-base | xargs -t -n 1 docker build
+    | grep -v wp-base | xargs -t -n 1 docker build $other_dockers_build_args

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     apt-get -qy autoremove && \
     apt-get clean
 
+RUN pip3 install ansible
 
 RUN mkdir /var/run/sshd && \
     sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config && \

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -41,6 +41,10 @@ COPY new-wp-site.sh /usr/local/bin/new-wp-site
 RUN chmod a+x /usr/local/bin/new-wp-site
 COPY ./docker-entrypoint.sh /
 
+ARG WP_OPS_BRANCH=master
+RUN set -e -x; cd /wp; git clone https://github.com/epfl-idevelop/wp-ops; \
+    cd wp-ops; git checkout ${WP_OPS_BRANCH}
+
 # setup access rights
 RUN sed -ir 's#www-data.*:/usr/sbin/nologin#www-data:x:33:33:www-data:/var/www:/bin/bash#' /etc/passwd && \
     mkdir -p /var/www/.ssh && \


### PR DESCRIPTION
- New `ARG WP_OPS_BRANCH` argument to `docker/mgmt/Dockerfile`, which lets one build the `mgmt` to include a specific branch of `wp-ops`
- Use that feature in `.travis.yml` so that the entire build is done on the pull-request branch
