### PR TITLE
[feature] Back up select Kubernetes objects to a Keybase-encrypted git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: all
+all: gitbackup
+
+# Change this if you lack access to either of these Keybase repositories:
+BACKUP_NAMESPACES = wwp wwp-test
+
+.PHONY: checkout
+checkout:
+	$(MAKE) wp-k8s-backup/wwp-test || true
+	$(MAKE) wp-k8s-backup/wwp || true
+
+k8s-backup/wwp-test:
+	git clone keybase://team/epfl_wp_test/k8s-backup
+
+k8s-backup/wwp:
+	git clone keybase://team/epfl_wp_prod/k8s-backup
+
+_BACKUP_REPOS = $(patsubst %, k8s-backup/%, $(BACKUP_NAMESPACES))
+_BACKUP_YAMLS = $(patsubst %, %/configmaps.yaml, $(_BACKUP_REPOS))
+
+.PHONY: gitbackup
+gitbackup: $(_BACKUP_YAMLS)
+	set -e -x;                                                                \
+        for keybase_repo in $(_BACKUP_REPOS); do                                  \
+	  (cd $$keybase_repo;                                                     \
+	   git add *.yaml;                                                        \
+	   git commit -m "`echo "Automatic commit\n\nmade with $(MAKE)"`" *.yaml; \
+	   git push);                                                             \
+	done
+
+k8s-backup/%/configmaps.yaml:
+	oc get -o yaml -n $* configmaps > $@


### PR DESCRIPTION
Right now we save only all configmaps in each namespace (wwp and
wwp-test).

- Created one Keybase repository per Kubernetes namespace in use

- Add Makefile to `oc get -o yaml` the objects, create an automated
  git commit, and push

- Still needed: wp-dev should daisy-chain `make checkout` to wp-ops