### PR TITLE
Do not consider github repo as file when installing plugin

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
 
     def _is_filename (self, from_piece):
         """
-        Tells if a path is a filename or not.
+        Tells if a path is a filename/folder name or not.
 
         :param from_piece: string describing plugin source.
         """

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -79,6 +79,8 @@ class ActionModule(ActionBase):
         :param from_piece: string describing plugin source.
         """
         return (from_piece != "wordpress.org/plugins"
+                # check if match a github repo
+                and not re.match(r'^https:\/\/github\.com\/[\w-]+\/[\w-]+(\/)?$', from_piece)
                 and not from_piece.endswith(".zip"))
 
 


### PR DESCRIPTION
Depuis le début de la migration des plugins que l'on a développés afin qu'ils aient chacun leur propre repo Github, des installations de plugin via Ansible ne fonctionnaient plus car le nom du repo ne correspondait plus au nom du plugin (ex: `epfl-menus` vs `wp-plugin-epfl-menus` ) et le script tentait d'installer un plugin qui portait le nom du repo

Ajout d'un petit check pour savoir si le `from` que l'on a mis dans le fichier `plugins.yml` est un repo Github ou pas au moment d'identifier si c'est un fichier qui est référencé