### PR TITLE
[feature] msmtp set_from_header 

### DIFF
--- a/docker/httpd/msmtprc
+++ b/docker/httpd/msmtprc
@@ -1,5 +1,5 @@
 defaults
-logfile        /var/log/msmtp.log
+logfile        -
 
 account        epfl
 host           mail.epfl.ch


### PR DESCRIPTION
Change the `msmtprc` configuration and redirect logs to standard output.