### PR TITLE
[feature] msmtp: log to stderr

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -11,8 +11,14 @@ RUN set -e -x; mkdir /build; cd /build;                                     \
     wget ${msmtp_url_base}-${msmtp_patchlevel}.dsc;                         \
     wget ${msmtp_url_base}.orig.tar.xz;                                     \
     wget ${msmtp_url_base}-${msmtp_patchlevel}.debian.tar.xz;               \
-    dpkg-source -x $(basename "${msmtp_url_base}")-${msmtp_patchlevel}.dsc; \
-    cd msmtp*; dpkg-buildpackage -d;                                        \
+    dpkg-source -x $(basename "${msmtp_url_base}")-${msmtp_patchlevel}.dsc
+
+COPY log-to-stderr.patch /build/
+
+RUN set -e -x; cd /build/msmtp*;                         \
+    cp /build/log-to-stderr.patch debian/patches/;       \
+    echo log-to-stderr.patch >> debian/patches/series;   \
+    dpkg-buildpackage -d;                                \
     mkdir /deb; mv ../*.deb /deb
 
 FROM docker-registry.default.svc:5000/wwp-test/wp-base

--- a/docker/httpd/log-to-stderr.patch
+++ b/docker/httpd/log-to-stderr.patch
@@ -1,0 +1,50 @@
+Index: msmtp-1.8.11/doc/msmtp.info
+===================================================================
+--- msmtp-1.8.11.orig/doc/msmtp.info
++++ msmtp-1.8.11/doc/msmtp.info
+@@ -345,7 +345,7 @@ argument and treats that as if it was �
+ ‘logfile [FILE]’
+      Enable logging to the specified file.  An empty argument disables
+      logging.  The file name ‘-’ directs the log information to standard
+-     output.  *Note Logging::.
++     error.  *Note Logging::.
+ ‘logfile_time_format [FMT]’
+      Set or unset the log file time format.  This will be used as the
+      format string for the strftime() function.  An empty argument
+Index: msmtp-1.8.11/doc/msmtp.texi
+===================================================================
+--- msmtp-1.8.11.orig/doc/msmtp.texi
++++ msmtp-1.8.11/doc/msmtp.texi
+@@ -416,7 +416,7 @@ new header line "To: undisclosed-recipie
+ @item logfile [@var{file}]
+ @cmindex logfile
+ Enable logging to the specified file. An empty argument disables logging. The
+-file name @samp{-} directs the log information to standard output.
++file name @samp{-} directs the log information to standard error.
+ @xref{Logging}.
+ @anchor{logfile_time_format}
+ @item logfile_time_format [@var{fmt}]
+Index: msmtp-1.8.11/src/msmtp.c
+===================================================================
+--- msmtp-1.8.11.orig/src/msmtp.c
++++ msmtp-1.8.11/src/msmtp.c
+@@ -1893,7 +1893,7 @@ void msmtp_log_to_file(const char *logfi
+     /* write log to file */
+     if (strcmp(logfile, "-") == 0)
+     {
+-        f = stdout;
++        f = stderr;
+     }
+     else
+     {
+--- msmtp-1.8.11.orig/doc/msmtp.1	2021-10-08 10:35:24.829585855 +0000
++++ msmtp-1.8.11/doc/msmtp.1	2021-10-08 10:35:34.915586350 +0000
+@@ -590,7 +590,7 @@
+ success).
+ .br
+ If the filename is a dash (\-), msmtp prints the log line to the standard
+-output.
++error.
+ .IP "logfile_time_format [\fIfmt\fP]"
+ Set or unset the log file time format. This will be used as the format string
+ for the strftime() function. An empty argument chooses the default


### PR DESCRIPTION
Patch the msmtp build so that `--logfile=-` (or the equivalent config
file option) logs to standard error rather than standard output.