### PR TITLE
[fix] Overlooked `epflsi/` image name, causing the Travis build to fail

### DIFF
--- a/docker/cronjob/Dockerfile
+++ b/docker/cronjob/Dockerfile
@@ -1,3 +1,3 @@
-FROM epflsi/os-wp-mgmt
+FROM docker-registry.default.svc:5000/wwp-test/mgmt
 
 USER www-data


### PR DESCRIPTION
See explanations at https://github.com/epfl-si/wp-dev/commit/2b366c27844fab414417ebe2924545fd08ddcece