### PR TITLE
[fix] Bug introduced in #456

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -138,7 +138,7 @@ class WordPressActionModule(ActionBase):
             # cloned) out of a fraction of a repository. On the other hand,
             # “other” things on GitHub (such as a whole repository, or a
             # released .zip) should return false.
-            return re.search(r'/blob/', from_piece)
+            return re.search(r'/(tree|blob)/', from_piece)
         else:
             return (from_piece != "wordpress.org/plugins"
                     and not from_piece.endswith(".zip"))


### PR DESCRIPTION
URLs like https://github.com/epfl-si/wp-mu-plugins/tree/master/epfl-quota also designate a “filename” in the sense of `_is_filename`, i.e. something to cherry-pick and install under the same basename as the end of the URL; as opposed to something to unpack (like a .zip or a full-blown Git checkout).
