### PR TITLE
[fix] Permissions in `/home/runner`

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -53,6 +53,7 @@ RUN groupdel $(getent group {{ awx_unix_credentials.uid }} |cut -d: -f1)
 RUN groupadd -g {{ awx_unix_credentials.gid }} {{ awx_unix_credentials.group }}
 RUN useradd -u {{ awx_unix_credentials.uid }} -g {{ awx_unix_credentials.gid }} -d /home/runner {{ awx_unix_credentials.user }}
 RUN chgrp -R {{ awx_unix_credentials.group }} /home/runner
+RUN chmod g+w /home/runner/.??*
 
 # Add dependencies
 RUN set -e -x; mkdir /tmp/install; \


### PR DESCRIPTION
Doing a `chgrp` is not enough, if the user still doesn't have write access.
