### PR TITLE
[fix] `callback_whitelist` is deprecated

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -7,7 +7,7 @@ jinja2_native = true
 ;; Disable the impossible-to-disable "argsplat" warning
 ;; (https://stackoverflow.com/a/56918548/435004):
 inject_facts_as_vars = false
-callback_whitelist = timer, profile_tasks
+callbacks_enabled = ansible.posix.timer, ansible.posix.profile_tasks
 ;; default is 5
 forks = 5
 strategy_plugins = ansible-deps-cache/python/lib/python3.7/site-packages/ansible_mitogen/plugins/strategy


### PR DESCRIPTION
Thanks to https://stackoverflow.com/a/71781869/960623:
> callback_whitelist is deprecated and will be removed in Ansible 2.15),
> callbacks_enabled (introduced in 2.11) should be used instead in
> modern versions of Ansible.