### PR TITLE
[enhancement] Optimize resources (CPU + memory) of report-uri

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/report-uri.yml
+++ b/ansible/roles/wordpress-namespace/tasks/report-uri.yml
@@ -149,8 +149,10 @@
                 imagePullPolicy: Always
                 resources:
                   requests:
-                    cpu: "100m"
-                    memory: "64Mi"
+                    cpu: "10m"
+                    memory: "256Mi"
+                  limits:
+                    memory: "256Mi"
                 readinessProbe:
                   tcpSocket:
                     port: 5050


### PR DESCRIPTION
* Optimize resources
  * requests.cpu: 100m → 10m
  * requests.memory: 64Mi → 256Mi
  * limit.memory: unset → 256Mi